### PR TITLE
Retrieve Version information without Importing

### DIFF
--- a/fxpmath/__init__.py
+++ b/fxpmath/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 
 import sys
 __maxsize__ = sys.maxsize

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,16 @@ project_folder = path.abspath(path.dirname(__file__))
 with open(path.join(project_folder, 'README.md'), 'r') as f:
     long_description = f.read()
 
-_version = __import__('fxpmath').__version__
+ def _get_version():
+    with open(path.join(project_folder, 'fxpmath', '__init__.py')) as f:
+        for line in f.readlines():
+            if line.startswith('__version__'):
+                return line.split("'")[1]
+
 
 setup(
     name='fxpmath',
-    version=_version,
+    version=_get_version(),
     author='francof2a',
     author_email='empty@empty.com',
     packages=['fxpmath'],

--- a/setup.py
+++ b/setup.py
@@ -8,16 +8,17 @@ project_folder = path.abspath(path.dirname(__file__))
 with open(path.join(project_folder, 'README.md'), 'r') as f:
     long_description = f.read()
 
- def _get_version():
+def _get_version():
     with open(path.join(project_folder, 'fxpmath', '__init__.py')) as f:
         for line in f.readlines():
             if line.startswith('__version__'):
                 return line.split("'")[1]
 
+_version = _get_version()
 
 setup(
     name='fxpmath',
-    version=_get_version(),
+    version=_version,
     author='francof2a',
     author_email='empty@empty.com',
     packages=['fxpmath'],


### PR DESCRIPTION
Retrieves version information without importing. 

Implements a suggested method of retrieving version information from the [Python packaging guide](https://packaging.python.org/guides/single-sourcing-package-version/).

Addresses issue #6.