### PR TITLE
Add string dtype support to Fxp initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ or just
 x = Fxp(-7.25, True, 16, 8)
 ```
 Formats can also be specified using a string, either in the fxp `dtype` format,
-or by using `Qm.n` or `UQm.n` notation (or the equivalent `Sm.n`/`Un.m notation). 
+or by using `Qm.n` or `UQm.n` notation (or the equivalent `Sm.n`/`Um.n` notation). 
 
 ```python
 x = Fxp(-7.25, dtype='fxp-s16/8')

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ from fxpmath import Fxp
 
 x = Fxp(-7.25)      # create fxp variable with value 7.25
 x.info()
+```
 
 > dtype           =       fxp-s6/2  
-> Value           =       -7.25  
+> Value           =       -7.25
 
 We have created a variable of 6 bits, where 1 bit has been reserved for sign, 2 bits for fractional part, and 3 remains for integer part. Here, bit sizes had been calculated to just satisfy the value you want to save.
 
@@ -116,6 +117,13 @@ or just
 
 ```python
 x = Fxp(-7.25, True, 16, 8)
+```
+Formats can also be specified using a string, either in the fxp `dtype` format,
+or by using `Qm.n` or `UQm.n` notation (or the equivalent `Sm.n`/`Un.m notation). 
+
+```python
+x = Fxp(-7.25, dtype='fxp-s16/8')
+x = Fxp(-7.25, dtype='S8.8')
 ```
 
 You can print more information only changing the verbosity of *info* method.
@@ -209,6 +217,12 @@ x = 10.75           # wrong
 ```
 
 because you are just modifying `x` type... it isn't a *Fxp* anymore, just a simple *float* right now.
+
+The same as `x.val` gives you the raw underlying value, you can set that value with
+
+```python
+x.set_val(43, raw=True)
+```
 
 ### changing size
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -44,6 +44,34 @@ def test_instances():
     assert x.n_int == 4
     assert x.n_word == 8
 
+    x = Fxp(7.5, dtype='UQ4.4')
+    assert x() == 7.5
+    assert x.signed == False
+    assert x.n_frac == 4
+    assert x.n_int == 4
+    assert x.n_word == 8
+    
+    x = Fxp(7.5, dtype='U4.4')
+    assert x() == 7.5
+    assert x.signed == False
+    assert x.n_frac == 4
+    assert x.n_int == 4
+    assert x.n_word == 8
+    
+    x = Fxp(7.5, dtype='fxp-u8/4')
+    assert x() == 7.5
+    assert x.signed == False
+    assert x.n_frac == 4
+    assert x.n_int == 4
+    assert x.n_word == 8
+    
+    x = Fxp(7.5, False, 8, 4)
+    assert x() == 7.5
+    assert x.signed == False
+    assert x.n_frac == 4
+    assert x.n_int == 4
+    assert x.n_word == 8
+    
     x = Fxp(7.5, True, n_frac=4, n_int=6)
     assert x() == 7.5
     assert x.signed == True
@@ -51,6 +79,27 @@ def test_instances():
     assert x.n_int == 6
     assert x.n_word == 11
 
+    x = Fxp(7.5, dtype='Q7.4')
+    assert x() == 7.5
+    assert x.signed == True
+    assert x.n_frac == 4
+    assert x.n_int == 6
+    assert x.n_word == 11
+
+    x = Fxp(7.5, dtype='S7.4')
+    assert x() == 7.5
+    assert x.signed == True
+    assert x.n_frac == 4
+    assert x.n_int == 6
+    assert x.n_word == 11
+
+    x = Fxp(7.5, dtype='fxp-s11/4')
+    assert x() == 7.5
+    assert x.signed == True
+    assert x.n_frac == 4
+    assert x.n_int == 6
+    assert x.n_word == 11
+    
     x = Fxp(3, False)
     assert x() == 3
     assert x.signed == False


### PR DESCRIPTION
Added support for a `dtype=` argument in the initializer, which allows the numerical format to be specified as a string, either in the same format the library already uses for dtype or as Q/S/U/QU/UQ m.n format, where m is the number of integer bits (regardless of signed or unsigned), n is the number of fractional bits, and m+n is always equal to the word length.  This cuts down on some verbosity when defining formats, and helps people already used to talking about their DSP data types in those terms.

I added tests into test_basic and documentation into README.md.

One note is that I was _not_ able to process the '-complex' argument on the end of a dtype string, so if present that's just ignored.  The library doesn't seem to care; complexity auto-determines as a function of the underlying value, so it doesn't need explicit specification.