### PR TITLE
0.4.7.dev

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+version 0.4.7
+--------------------------------------------------
+* Keep val as original_vdtype and not as object when it is convenient (solve issue #60).
+* Convert vdtype to float when scaling transformation is applied.
+* Add `abs` method. 
+
 version 0.4.6
 --------------------------------------------------
 * Fix complex `truediv` and `floordiv` methods (issue #53).

--- a/fxpmath/__init__.py
+++ b/fxpmath/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.6'
+__version__ = '0.4.7.dev0'
 
 import sys
 import os

--- a/fxpmath/__init__.py
+++ b/fxpmath/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.7.dev0'
+__version__ = '0.4.7.rc0'
 
 import sys
 import os

--- a/tests/test_complex_numbers.py
+++ b/tests/test_complex_numbers.py
@@ -89,6 +89,12 @@ def test_math_operations():
     z_fxp = x_fxp // c
     assert z_fxp() == z
 
+    # abs
+    x = -3.0 + 1j*4.0
+    x_fxp = Fxp(x, dtype='Q16.16')
+
+    assert abs(x_fxp)() == 5.0
+
 def test_complex_repr():
     c_fxp = Fxp(1 + 1j*15)
     assert c_fxp.bin() == '00001+01111j'

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -420,3 +420,13 @@ def test_scaled():
     assert x - 2.5 == 8.0
     assert x * 3 == 31.5
     assert x / 2 == 5.25
+
+def test_abs():
+    x = Fxp(-3.5, True, 32, 16)
+
+    assert x() == -3.5
+    assert abs(x)() == 3.5
+
+    x = Fxp(3.5, True, 32, 16)
+    assert abs(x)() == 3.5
+    


### PR DESCRIPTION
* Keep val as original_vdtype and not as object when it is convenient (solve issue #60).
* Convert vdtype to float when scaling transformation is applied.
* Add `abs` method. 