### PR TITLE
Implements 'Keep' Shifting Config

### DIFF
--- a/fxpmath/objects.py
+++ b/fxpmath/objects.py
@@ -1344,11 +1344,11 @@ class Fxp():
         y = Fxp(None, signed=self.signed, n_word=n_word, n_frac=self.n_frac)
         
         if self.config.shifting == "keep":
-            a = self.val << np.array(n, dtype=self.val.dtype)
-            b = np.array((1 << n_word) - 1, dtype=self.val.dtype)
+            shift = self.val << np.array(n, dtype=self.val.dtype)
+            mask = np.array((1 << n_word) - 1, dtype=self.val.dtype)
             # this formatting is necessary for when shifting a 1 in a signed number
             # into the MSB. i.e. 1 << 7 == -128, not 127
-            y.set_val(f"0b{(a & b):0{n_word}b}",raw=True, vdtype=self.vdtype)
+            y.set_val(f"0b{(shift & mask):0{n_word}b}",raw=True, vdtype=self.vdtype)
         else:
             y.set_val(self.val << np.array(n, dtype=self.val.dtype), raw=True, vdtype=self.vdtype)   # set raw val shifted
             

--- a/fxpmath/objects.py
+++ b/fxpmath/objects.py
@@ -32,8 +32,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-#%% 
-import numpy as np 
+# %%
+import numpy as np
 import math
 import copy
 import re
@@ -49,9 +49,10 @@ try:
 except:
     Decimal = type(None)
 
-#%%
-class Fxp():
-    '''
+
+# %%
+class Fxp:
+    """
     Numerical Fractional Fixed-Point object (base 2).
 
     Parameters
@@ -59,7 +60,7 @@ class Fxp():
 
     val : None, int, float, complex, list of numbers, numpy array, str (bin, hex, dec), optional, default=None
         Value(s) to be stored in fractional fixed-point (base 2) format.
-    
+
     signed : bool, optional, default=None
         If True, a sign bit is used for the binary word. If None, Fxp is signed.
 
@@ -77,7 +78,7 @@ class Fxp():
 
     like : Fxp, optional, default=None
         Init new Fxp object using all parameters of `like` Fxp object, except its value.
-        
+
     dtype : str, optional, default=None
         String describing the desired fixed-point format in either Q/UQ, S/U, or fxp dtype format.
 
@@ -128,16 +129,26 @@ class Fxp():
     callbacks : list
         List of callbacks.
 
-    '''
+    """
 
     template = None
 
-    def __init__(self, val=None, signed=None, n_word=None, n_frac=None, n_int=None, like=None, dtype=None, **kwargs):
+    def __init__(
+        self,
+        val=None,
+        signed=None,
+        n_word=None,
+        n_frac=None,
+        n_int=None,
+        like=None,
+        dtype=None,
+        **kwargs,
+    ):
 
         # Init all properties in None
-        self._dtype = 'fxp' # fxp-<sign><n_word>/<n_frac>-{complex}. i.e.: fxp-s16/15, fxp-u8/1, fxp-s32/24-complex
+        self._dtype = "fxp"  # fxp-<sign><n_word>/<n_frac>-{complex}. i.e.: fxp-s16/15, fxp-u8/1, fxp-s32/24-complex
         # value
-        self.vdtype = None # value(s) dtype to return as default
+        self.vdtype = None  # value(s) dtype to return as default
         self.val = None
         self.real = None
         self.imag = None
@@ -155,10 +166,10 @@ class Fxp():
         self.upper = None
         self.lower = None
         self.precision = None
-        #status
+        # status
         self.status = None
         self.callbacks = None
-        #config
+        # config
         self.config = None
 
         _initialized = False
@@ -168,7 +179,8 @@ class Fxp():
         self.config = Config()
 
         # if `template` is in kwarg, the reference template is updated
-        if 'template' in kwargs: self.template = kwargs.pop('template')
+        if "template" in kwargs:
+            self.template = kwargs.pop("template")
 
         # check if init must be a `like` other Fxp
         if like is not None:
@@ -188,34 +200,39 @@ class Fxp():
                 self.imag = None
                 _initialized = True
 
-        #status (overwrite)
+        # status (overwrite)
         self.status = {
-            'overflow': False,
-            'underflow': False,
-            'inaccuracy': False,
-            'extended_prec': False}
+            "overflow": False,
+            "underflow": False,
+            "inaccuracy": False,
+            "extended_prec": False,
+        }
 
         # update config as argument
-        _config = kwargs.pop('config', None)
+        _config = kwargs.pop("config", None)
         if _config is not None:
             if isinstance(_config, Config):
                 self.config = _config.deepcopy()
             else:
-                raise TypeError('config parameter must be Config class type!')
+                raise TypeError("config parameter must be Config class type!")
 
         # update config from kwargs
         self.config.update(**kwargs)
 
         # callbacks
-        if self.callbacks is None: self.callbacks = kwargs.pop('callbacks', [])
+        if self.callbacks is None:
+            self.callbacks = kwargs.pop("callbacks", [])
 
         # scaling
-        if self.scale is None: self.scale = kwargs.pop('scale', 1)
-        if self.bias is None: self.bias = kwargs.pop('bias', 0)
+        if self.scale is None:
+            self.scale = kwargs.pop("scale", 1)
+        if self.bias is None:
+            self.bias = kwargs.pop("bias", 0)
         self.scaled = True if self.scale != 1 or self.bias != 0 else False
 
         # check if val is a raw value
-        if raw is None: raw = kwargs.pop('raw', False)
+        if raw is None:
+            raw = kwargs.pop("raw", False)
 
         # check if a string-based format has been provided
         if dtype is not None:
@@ -225,7 +242,16 @@ class Fxp():
 
         # size
         if not _initialized:
-            self._init_size(val, signed, n_word, n_frac, n_int, max_error=self.config.max_error, n_word_max=self.config.n_word_max, raw=raw)
+            self._init_size(
+                val,
+                signed,
+                n_word,
+                n_frac,
+                n_int,
+                max_error=self.config.max_error,
+                n_word_max=self.config.n_word_max,
+                raw=raw,
+            )
         else:
             # overwrite with other sizes if some are not None
             self.resize(signed, n_word, n_frac, n_int)
@@ -249,7 +275,7 @@ class Fxp():
     @property
     def overflow(self):
         return self.config.overflow
-    
+
     @overflow.setter
     def overflow(self, val):
         self.config.overflow = val
@@ -258,7 +284,7 @@ class Fxp():
     @property
     def rounding(self):
         return self.config.rounding
-    
+
     @rounding.setter
     def rounding(self, val):
         self.config.rounding = val
@@ -267,7 +293,7 @@ class Fxp():
     @property
     def shifting(self):
         return self.config.shifting
-    
+
     @shifting.setter
     def shifting(self, val):
         self.config.shifting = val
@@ -283,7 +309,6 @@ class Fxp():
     @property
     def size(self):
         return self.val.size
-
 
     # endregion
 
@@ -312,19 +337,19 @@ class Fxp():
             String describing the fixed-point format in either Q/UQ, S/U, or fxp dtype format (default).
 
         """
-        self._update_dtype(notation)    # update dtype
+        self._update_dtype(notation)  # update dtype
         return self._dtype
-    
-    _qfmt   = re.compile(r'(s|u|q|uq|qu)(\d+)(\.\d+)?')
-    _fxpfmt = re.compile(r'fxp-(s|u)(\d+)/(\d+)(-complex)?')
-    
+
+    _qfmt = re.compile(r"(s|u|q|uq|qu)(\d+)(\.\d+)?")
+    _fxpfmt = re.compile(r"fxp-(s|u)(\d+)/(\d+)(-complex)?")
+
     def _parseformatstr(self, fmt):
         fmt = fmt.casefold()
         mo = self._qfmt.match(fmt)
         if mo:
             # Q/S notation counts the sign bit as an integer bit, such that
             # the total number of bits is always int+frac
-            signed = mo.group(1) in 'sq'
+            signed = mo.group(1) in "sq"
             n_int = int(mo.group(2))
             if mo.group(3) is None:
                 n_frac = 0
@@ -335,26 +360,36 @@ class Fxp():
         else:
             mo = self._fxpfmt.match(fmt)
             if mo:
-                signed = mo.group(1) == 's'
+                signed = mo.group(1) == "s"
                 n_word = int(mo.group(2))
                 n_frac = int(mo.group(3))
                 complex_dtype = False
                 if mo.lastindex > 3:
                     _complex_str = str(mo.group(4))
-                    if _complex_str == '-complex':
+                    if _complex_str == "-complex":
                         complex_dtype = True
-                        
+
             else:
-                raise ValueError('unrecognized format string')
+                raise ValueError("unrecognized format string")
         return signed, n_word, n_frac, complex_dtype
-    
-    def _init_size(self, val=None, signed=None, n_word=None, n_frac=None, n_int=None, max_error=_max_error, n_word_max=_n_word_max, raw=False):
+
+    def _init_size(
+        self,
+        val=None,
+        signed=None,
+        n_word=None,
+        n_frac=None,
+        n_int=None,
+        max_error=_max_error,
+        n_word_max=_n_word_max,
+        raw=False,
+    ):
         # sign by default
         if signed is None:
             self.signed = True
         else:
             self.signed = signed
-        
+
         # n_int defined:
         if n_word is None and n_frac is not None and n_int is not None:
             n_word = n_int + n_frac + (1 if self.signed else 0)
@@ -363,11 +398,21 @@ class Fxp():
 
         # check if I must find the best size for val
         if n_word is None or n_frac is None:
-            self.set_best_sizes(val, n_word, n_frac, max_error=max_error, n_word_max=n_word_max, raw=raw)
+            self.set_best_sizes(
+                val, n_word, n_frac, max_error=max_error, n_word_max=n_word_max, raw=raw
+            )
         else:
             self.resize(self.signed, n_word, n_frac, n_int)
 
-    def resize(self, signed=None, n_word=None, n_frac=None, n_int=None, restore_val=True, dtype=None):
+    def resize(
+        self,
+        signed=None,
+        n_word=None,
+        n_frac=None,
+        n_int=None,
+        restore_val=True,
+        dtype=None,
+    ):
         """
         Change size of one or more of size parameters (signed, n_word, n_int and/or n_frac) of the Fxp object.
 
@@ -401,8 +446,15 @@ class Fxp():
 
         # check if a string-based format has been provided
         if dtype is not None:
-            if signed is not None or n_word is not None or n_frac is not None or n_int is not None:
-                raise ValueError('If dtype is specified, other sizing parameters must be `None`!')
+            if (
+                signed is not None
+                or n_word is not None
+                or n_frac is not None
+                or n_int is not None
+            ):
+                raise ValueError(
+                    "If dtype is specified, other sizing parameters must be `None`!"
+                )
             signed, n_word, n_frac, complex_flag = self._parseformatstr(dtype)
 
             self.vdtype = complex if complex_flag else self.vdtype
@@ -422,23 +474,23 @@ class Fxp():
         # frac
         if n_frac is not None:
             self.n_frac = n_frac
-    
-        # n_int    
+
+        # n_int
         self.n_int = self.n_word - self.n_frac - (1 if self.signed else 0)
 
         # status extended precision
         if self.n_word >= _n_word_max:
-            self.status['extended_prec'] = True
+            self.status["extended_prec"] = True
         else:
-            self.status['extended_prec'] = False
+            self.status["extended_prec"] = False
 
         # upper and lower limits
         if self.signed:
-            upper_val = (1 << (self.n_word-1)) - 1
+            upper_val = (1 << (self.n_word - 1)) - 1
             lower_val = -upper_val - 1
         else:
-            upper_val =  (1 << self.n_word) - 1
-            lower_val = 0 
+            upper_val = (1 << self.n_word) - 1
+            lower_val = 0
 
         if self.vdtype == complex:
             self.upper = (upper_val + 1j * upper_val) / 2.0**self.n_frac
@@ -460,14 +512,22 @@ class Fxp():
             if self.scaled:
                 self.set_val((_old_val / 2**_old_n_frac) * self.scale + self.bias)
             else:
-                self.set_val(_old_val * 2**(self.n_frac - _old_n_frac), raw=True)
+                self.set_val(_old_val * 2 ** (self.n_frac - _old_n_frac), raw=True)
         else:
             self.set_val(_old_val, raw=True)
 
         # update dtype
         self._update_dtype()
-    
-    def set_best_sizes(self, val=None, n_word=None, n_frac=None, max_error=1.0e-6, n_word_max=64, raw=False):
+
+    def set_best_sizes(
+        self,
+        val=None,
+        n_word=None,
+        n_frac=None,
+        max_error=1.0e-6,
+        n_word_max=64,
+        raw=False,
+    ):
 
         if val is None:
             if n_word is None and n_frac is None:
@@ -487,9 +547,11 @@ class Fxp():
 
             self.n_word = n_word
             self.n_frac = n_frac
-            
+
             # if val is a str(s), convert to number(s)
-            val, _, raw, signed, n_word, n_frac = self._format_inupt_val(val, return_sizes=True, raw=raw)
+            val, _, raw, signed, n_word, n_frac = self._format_inupt_val(
+                val, return_sizes=True, raw=raw
+            )
             val = np.array([val])
 
             # check if val is complex, if it is: convert to array of float/int
@@ -497,13 +559,13 @@ class Fxp():
                 val_real = np.vectorize(lambda v: v.real)(val)
                 val_imag = np.vectorize(lambda v: v.imag)(val)
                 val = np.array([val_real, val_imag])
-            
+
             # if val is raw
             if raw:
                 if self.n_frac is not None:
                     val = val / self._get_conv_factor()
                 else:
-                    raise ValueError('for raw value, `n_frac` must be defined!')
+                    raise ValueError("for raw value, `n_frac` must be defined!")
 
             # define numpy integer type
             if self.signed:
@@ -512,7 +574,7 @@ class Fxp():
                 int_dtype = np.uint64
 
             # find fractional parts
-            frac_vals = np.abs(val%1).ravel()
+            frac_vals = np.abs(val % 1).ravel()
 
             # n_frac estimation
             if n_frac is None:
@@ -533,9 +595,9 @@ class Fxp():
 
             # max raw value (integer) estimation
             # n_int = max( np.ceil(np.log2(np.max(np.abs( val*(1 << n_frac) + 0.5 )))).astype(int_dtype) - n_frac, 0)
-            
-            val_max = int(np.max(val)*(1 << n_frac))
-            val_min = int(np.min(val)*(1 << n_frac))
+
+            val_max = int(np.max(val) * (1 << n_frac))
+            val_min = int(np.min(val) * (1 << n_frac))
             n_int = 0
             while n_int < n_word_max - sign:
                 msb_max = (val_max >> n_int) + (1 if val_max < 0 else 0)
@@ -549,32 +611,34 @@ class Fxp():
 
             # size assignement
             if n_word is None:
-                n_frac = min(n_word_max - sign - n_int, n_frac) # n_frac limit according n_word max size
+                n_frac = min(
+                    n_word_max - sign - n_int, n_frac
+                )  # n_frac limit according n_word max size
                 self.n_frac = int(n_frac)
                 self.n_word = int(n_frac + n_int + sign)
             else:
                 self.n_word = int(n_word)
                 self.n_frac = n_frac = int(min(n_word - sign - n_int, n_frac))
-        
+
         self.n_word = int(min(self.n_word, n_word_max))
         self.resize(restore_val=False)
 
-    def reshape(self, shape, order='C'):
+    def reshape(self, shape, order="C"):
         """
         Reshape the fixed-point array.
 
         Parameters
         ---
         shape : int or tuple of ints
-            The new shape should be compatible with the original shape. 
-            If an integer, then the result will be a 1-D array of that length. 
+            The new shape should be compatible with the original shape.
+            If an integer, then the result will be a 1-D array of that length.
             One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.
 
         order : {‘C’, ‘F’, ‘A’}, optional
-            Read the elements of a using this index order, and place the elements into the reshaped array using this index order. 
-            ‘C’ means to read / write the elements using C-like index order, with the last axis index changing fastest, back to the first axis index changing slowest. 
-            ‘F’ means to read / write the elements using Fortran-like index order, with the first index changing fastest, and the last index changing slowest. 
-            Note that the ‘C’ and ‘F’ options take no account of the memory layout of the underlying array, and only refer to the order of indexing. 
+            Read the elements of a using this index order, and place the elements into the reshaped array using this index order.
+            ‘C’ means to read / write the elements using C-like index order, with the last axis index changing fastest, back to the first axis index changing slowest.
+            ‘F’ means to read / write the elements using Fortran-like index order, with the first index changing fastest, and the last index changing slowest.
+            Note that the ‘C’ and ‘F’ options take no account of the memory layout of the underlying array, and only refer to the order of indexing.
             ‘A’ means to read / write the elements in Fortran-like index order if a is Fortran contiguous in memory, C-like order otherwise.
 
         Returns
@@ -583,11 +647,11 @@ class Fxp():
             Same Fxp object with its reshaped values array.
 
         """
-        
+
         self.val = self.val.reshape(shape=shape, order=order)
         return self
-    
-    def flatten(self, order='C'):
+
+    def flatten(self, order="C"):
         """
         Return a copy of the Fxp with its values array collapsed into one dimension.
 
@@ -595,10 +659,10 @@ class Fxp():
         ---
 
         order{‘C’, ‘F’, ‘A’, ‘K’}, optional
-            ‘C’ means to flatten in row-major (C-style) order. 
-            ‘F’ means to flatten in column-major (Fortran- style) order. 
-            ‘A’ means to flatten in column-major order if a is Fortran contiguous in memory, row-major order otherwise. 
-            ‘K’ means to flatten a in the order the elements occur in memory. 
+            ‘C’ means to flatten in row-major (C-style) order.
+            ‘F’ means to flatten in column-major (Fortran- style) order.
+            ‘A’ means to flatten in column-major order if a is Fortran contiguous in memory, row-major order otherwise.
+            ‘K’ means to flatten a in the order the elements occur in memory.
             The default is ‘C’.
 
         Returns
@@ -632,11 +696,14 @@ class Fxp():
             # if val is an Fxp object
             vdtype = val.vdtype
             # if some of signed, n_word, n_frac is not defined, they are copied from val
-            if self.signed is None: self.signed = val.signed
-            if self.n_word is None: self.n_word = val.n_word
-            if self.n_frac is None: self.n_frac = val.n_frac
+            if self.signed is None:
+                self.signed = val.signed
+            if self.n_word is None:
+                self.n_word = val.n_word
+            if self.n_frac is None:
+                self.n_frac = val.n_frac
             # force return raw value for better precision
-            val = val.val * 2**(self.n_frac - val.n_frac)
+            val = val.val * 2 ** (self.n_frac - val.n_frac)
             raw = True
 
         elif isinstance(val, (int, float, complex)):
@@ -647,7 +714,7 @@ class Fxp():
                 vdtype = type(val.item(0))
             else:
                 vdtype = val.dtype
-            
+
             try:
                 if isinstance(val, np.float128):
                     val = np.array(float(val))
@@ -660,9 +727,13 @@ class Fxp():
                 val = val.tolist()
 
                 if not raw:
-                    val, signed, n_word, n_frac = utils.str2num(val, self.signed, self.n_word, self.n_frac, return_sizes=True)
+                    val, signed, n_word, n_frac = utils.str2num(
+                        val, self.signed, self.n_word, self.n_frac, return_sizes=True
+                    )
                 else:
-                    val, signed, n_word, _ = utils.str2num(val, self.signed, self.n_word, None, return_sizes=True)
+                    val, signed, n_word, _ = utils.str2num(
+                        val, self.signed, self.n_word, None, return_sizes=True
+                    )
                     n_frac = self.n_frac
 
                 if n_frac is not None and n_frac == 0:
@@ -673,32 +744,37 @@ class Fxp():
         elif isinstance(val, (list, tuple, str)):
             # if val is a str(s), convert to number(s)
             if not raw:
-                val, signed, n_word, n_frac = utils.str2num(val, self.signed, self.n_word, self.n_frac, return_sizes=True)
+                val, signed, n_word, n_frac = utils.str2num(
+                    val, self.signed, self.n_word, self.n_frac, return_sizes=True
+                )
             else:
-                val, signed, n_word, _ = utils.str2num(val, self.signed, self.n_word, None, return_sizes=True)
+                val, signed, n_word, _ = utils.str2num(
+                    val, self.signed, self.n_word, None, return_sizes=True
+                )
                 n_frac = self.n_frac
 
         elif isinstance(val, Decimal):
-            vdtype = float            # assuming float format
+            vdtype = float  # assuming float format
 
             if self.n_frac is None:
                 # estimate n_frac from decimal precision
-                self.n_frac = n_frac = int(np.ceil(math.log2(10**int(getcontext().prec))))
+                self.n_frac = n_frac = int(
+                    np.ceil(math.log2(10 ** int(getcontext().prec)))
+                )
 
             # force return raw value for better precision
-            val = int(val * 2**(self.n_frac))
+            val = int(val * 2 ** (self.n_frac))
             raw = True
 
-
         else:
-            raise ValueError('Not supported input type: {}'.format(type(val)))
+            raise ValueError("Not supported input type: {}".format(type(val)))
 
         # convert to (numpy) ndarray
         val = np.array(val)
 
         if vdtype is None:
             vdtype = val.dtype
-        
+
         # scaling conversion
         self.scaled = False
         if self.scale is not None and self.bias is not None and not raw:
@@ -708,12 +784,12 @@ class Fxp():
                 val = val / self.scale
 
             if self.bias != 0 or self.scale != 1:
-                self.scaled = True # update scaled flag
+                self.scaled = True  # update scaled flag
 
                 # update vdtype due scaling tranformation
                 if vdtype == int and (isinstance(self.bias, float) or self.scale != 1):
                     vdtype = float
-            
+
             # check if it is a numpy array
             if not isinstance(val, (np.ndarray, np.generic)):
                 val = np.array(val)
@@ -729,9 +805,9 @@ class Fxp():
         if raw:
             conv_factor = 1
         elif self.n_frac >= 0:
-            conv_factor = (1<<self.n_frac)
+            conv_factor = 1 << self.n_frac
         else:
-            conv_factor = 1/(1<<-self.n_frac)
+            conv_factor = 1 / (1 << -self.n_frac)
 
         return conv_factor
 
@@ -739,24 +815,38 @@ class Fxp():
         if notation is None:
             notation = self.config.dtype_notation
         else:
-            notation = 'fxp'
+            notation = "fxp"
 
-        if self.signed is not None and self.n_word is not None and self.n_frac is not None:
-            if notation == 'Q':
-                self._dtype = '{Q}{nint}.{nfrac}'.format(Q='Q' if self.signed else 'UQ',
-                                                        nint=self.n_word-self.n_frac,
-                                                        nfrac=self.n_frac)
+        if (
+            self.signed is not None
+            and self.n_word is not None
+            and self.n_frac is not None
+        ):
+            if notation == "Q":
+                self._dtype = "{Q}{nint}.{nfrac}".format(
+                    Q="Q" if self.signed else "UQ",
+                    nint=self.n_word - self.n_frac,
+                    nfrac=self.n_frac,
+                )
             elif self.val is not None:
-                self._dtype = 'fxp-{sign}{nword}/{nfrac}{comp}'.format(sign='s' if self.signed else 'u', 
-                                                                    nword=self.n_word, 
-                                                                    nfrac=self.n_frac, 
-                                                                    comp='-complex' if (self.val.dtype == complex or self.vdtype == complex) else '')
+                self._dtype = "fxp-{sign}{nword}/{nfrac}{comp}".format(
+                    sign="s" if self.signed else "u",
+                    nword=self.n_word,
+                    nfrac=self.n_frac,
+                    comp=(
+                        "-complex"
+                        if (self.val.dtype == complex or self.vdtype == complex)
+                        else ""
+                    ),
+                )
             else:
-                self._dtype = 'fxp-{sign}{nword}/{nfrac}'.format(sign='s' if self.signed else 'u', 
-                                                                    nword=self.n_word, 
-                                                                    nfrac=self.n_frac)                
+                self._dtype = "fxp-{sign}{nword}/{nfrac}".format(
+                    sign="s" if self.signed else "u",
+                    nword=self.n_word,
+                    nfrac=self.n_frac,
+                )
         else:
-            self._dtype = 'fxp'
+            self._dtype = "fxp"
 
     def set_val(self, val, raw=False, vdtype=None, index=None):
         """
@@ -781,7 +871,7 @@ class Fxp():
         ---
 
         self : Fxp object
-            Fxp with it's value modified. 
+            Fxp with it's value modified.
 
         """
 
@@ -790,20 +880,26 @@ class Fxp():
 
         # val limits according word size
         if self.signed:
-            val_max = (1 << (self.n_word-1)) - 1
+            val_max = (1 << (self.n_word - 1)) - 1
             val_min = -val_max - 1
         else:
-            val_max =  (1 << self.n_word) - 1
+            val_max = (1 << self.n_word) - 1
             val_min = 0
 
         # conversion factor
         conv_factor = self._get_conv_factor(raw)
 
         # round, saturate and store
-        if original_vdtype != complex and not np.issubdtype(original_vdtype, np.complexfloating):
+        if original_vdtype != complex and not np.issubdtype(
+            original_vdtype, np.complexfloating
+        ):
             # val_dtype determination
             _n_word_max_ = min(_n_word_max, 64)
-            if np.max(val) >= 2**_n_word_max_ or np.min(val) < -2**_n_word_max_ or self.n_word >= _n_word_max_:
+            if (
+                np.max(val) >= 2**_n_word_max_
+                or np.min(val) < -(2**_n_word_max_)
+                or self.n_word >= _n_word_max_
+            ):
                 val_dtype = object
                 val = val.astype(object)
             else:
@@ -811,16 +907,20 @@ class Fxp():
                 val_dtype = np.int64 if self.signed else np.uint64
 
             # rounding and overflowing
-            new_val = self._round(val * conv_factor , method=self.config.rounding)
+            new_val = self._round(val * conv_factor, method=self.config.rounding)
             new_val = self._overflow_action(new_val, val_min, val_max)
 
             # convert to array of val_dtype
             new_val = new_val.astype(val_dtype)
 
-            if val_dtype == object:       
+            if val_dtype == object:
                 # convert each element to int
-                new_val = np.array(list(map(int, new_val.flatten()))).reshape(new_val.shape).astype(val_dtype)
-            
+                new_val = (
+                    np.array(list(map(int, new_val.flatten())))
+                    .reshape(new_val.shape)
+                    .astype(val_dtype)
+                )
+
             if index is not None:
                 self.val[index] = new_val
             else:
@@ -833,18 +933,26 @@ class Fxp():
             # extract real and imaginary parts
             new_val_real = np.vectorize(lambda v: v.real)(val)
             new_val_imag = np.vectorize(lambda v: v.imag)(val)
-            
+
             # val_dtype determination
             _n_word_max_ = min(_n_word_max, 64)
-            if np.max(new_val_real) >= 2**_n_word_max_ or np.min(new_val_real) < -2**_n_word_max_ or self.n_word >= _n_word_max_:
+            if (
+                np.max(new_val_real) >= 2**_n_word_max_
+                or np.min(new_val_real) < -(2**_n_word_max_)
+                or self.n_word >= _n_word_max_
+            ):
                 val_dtype = object
             else:
                 val = val.astype(original_vdtype)
                 val_dtype = np.int64 if self.signed else np.uint64
-            
+
             # rounding and overflowing
-            new_val_real = self._round(new_val_real * conv_factor, method=self.config.rounding)
-            new_val_imag = self._round(new_val_imag * conv_factor, method=self.config.rounding)
+            new_val_real = self._round(
+                new_val_real * conv_factor, method=self.config.rounding
+            )
+            new_val_imag = self._round(
+                new_val_imag * conv_factor, method=self.config.rounding
+            )
             new_val_real = self._overflow_action(new_val_real, val_min, val_max)
             new_val_imag = self._overflow_action(new_val_imag, val_min, val_max)
 
@@ -852,11 +960,15 @@ class Fxp():
             new_val_real = new_val_real.astype(val_dtype)
             new_val_imag = new_val_imag.astype(val_dtype)
 
-            if val_dtype == object:       
+            if val_dtype == object:
                 # convert each element to int
-                new_val_real = np.array(list(map(int, new_val_real.flatten()))).reshape(new_val_real.shape)
-                new_val_imag = np.array(list(map(int, new_val_imag.flatten()))).reshape(new_val_imag.shape)
-            
+                new_val_real = np.array(list(map(int, new_val_real.flatten()))).reshape(
+                    new_val_real.shape
+                )
+                new_val_imag = np.array(list(map(int, new_val_imag.flatten()))).reshape(
+                    new_val_imag.shape
+                )
+
             # rebuild complex
             new_val = new_val_real + 1j * new_val_imag
 
@@ -881,12 +993,12 @@ class Fxp():
                 self.vdtype = float  # change to float type if Fxp has fractional part
 
         # check inaccuracy
-        if not np.equal(val, new_val/conv_factor).all() :
-            self.status['inaccuracy'] = True
-            self._run_callbacks('on_status_inaccuracy')
+        if not np.equal(val, new_val / conv_factor).all():
+            self.status["inaccuracy"] = True
+            self._run_callbacks("on_status_inaccuracy")
 
         # run changed value callback
-        self._run_callbacks('on_value_change')
+        self._run_callbacks("on_value_change")
 
         return self
 
@@ -901,7 +1013,7 @@ class Fxp():
             Typecode or data-type to which the array is cast.
 
             `None` returns according to `vdtype` of Fxp, if last one is `None`, `float` is returned.
-        
+
         index : int, optional, default=None
             Index of the element to return from list or array of values cast according `dtype`.
 
@@ -937,13 +1049,18 @@ class Fxp():
                 val = raw_val / self._get_conv_factor()
                 if isinstance(val, np.ndarray):
                     val = val.astype(dtype)
-            elif dtype == int or dtype == 'uint' or dtype == 'int' or np.issubdtype(dtype, np.integer):
+            elif (
+                dtype == int
+                or dtype == "uint"
+                or dtype == "int"
+                or np.issubdtype(dtype, np.integer)
+            ):
                 if self.n_frac == 0:
                     val = raw_val
                 else:
                     val = raw_val // self._get_conv_factor()
                     val = np.array(list(map(int, val.flatten()))).reshape(val.shape)
-                
+
             elif dtype == complex or np.issubdtype(dtype, np.complexfloating):
                 val = (raw_val.real + 1j * raw_val.imag) / self._get_conv_factor()
             else:
@@ -967,7 +1084,7 @@ class Fxp():
             Typecode or data-type to which the array is cast.
 
             `None` returns according to `vdtype` of Fxp, if last one is `None`, `float` is returned.
-        
+
         index : int, optional, default=None
             Index of the element to return from list or array of values cast according `dtype`.
 
@@ -983,7 +1100,7 @@ class Fxp():
         ---
         val : number or array
             Value represented in original format (not binary) casted according to `dtype`.
-            
+
         """
 
         if dtype is None:
@@ -1002,7 +1119,7 @@ class Fxp():
         """
 
         return self.val
-    
+
     def uraw(self):
         """
         Returns a tow-complement of fixed-point integer value (unsigned raw value).
@@ -1029,11 +1146,11 @@ class Fxp():
         ---
 
         self : Fxp object
-            Fxp with it's value modified. 
+            Fxp with it's value modified.
         """
-        
+
         if isinstance(x, Fxp):
-            new_val_raw = x.val * 2**(self.n_frac - x.n_frac)
+            new_val_raw = x.val * 2 ** (self.n_frac - x.n_frac)
             self.set_val(new_val_raw, raw=True)
         else:
             self.set_val(x)
@@ -1043,47 +1160,54 @@ class Fxp():
 
     def _overflow_action(self, new_val, val_min, val_max):
         if np.any(new_val > val_max):
-            self.status['overflow'] = True
-            self._run_callbacks('on_status_overflow')
+            self.status["overflow"] = True
+            self._run_callbacks("on_status_overflow")
         if np.any(new_val < val_min):
-            self.status['underflow'] = True
-            self._run_callbacks('on_status_underflow')
-        
-        if self.config.overflow == 'saturate':
+            self.status["underflow"] = True
+            self._run_callbacks("on_status_underflow")
+
+        if self.config.overflow == "saturate":
             if isinstance(new_val, np.ndarray) and new_val.dtype == object:
                 val = np.clip(new_val, val_min, val_max)
             else:
                 val = utils.clip(new_val, val_min, val_max)
 
-        elif self.config.overflow == 'wrap':
+        elif self.config.overflow == "wrap":
             val = utils.wrap(new_val, self.signed, self.n_word)
         else:
-            raise ValueError('{} is not a valid config for overflow!'.format(self.config.overflow))
+            raise ValueError(
+                "{} is not a valid config for overflow!".format(self.config.overflow)
+            )
         return val
 
-    def _round(self, val, method='floor'):
-        if isinstance(val, int) or np.issubdtype(np.array(val).dtype, np.integer) or np.issubdtype(np.array(val).dtype, np.object_):
+    def _round(self, val, method="floor"):
+        if (
+            isinstance(val, int)
+            or np.issubdtype(np.array(val).dtype, np.integer)
+            or np.issubdtype(np.array(val).dtype, np.object_)
+        ):
             rval = val
-        elif method == 'around':
+        elif method == "around":
             rval = np.around(val)
-        elif method == 'floor':
+        elif method == "floor":
             rval = np.floor(val)
-        elif method == 'ceil':
+        elif method == "ceil":
             rval = np.ceil(val)
-        elif method == 'fix':
+        elif method == "fix":
             rval = np.fix(val)
-        elif method == 'trunc':
+        elif method == "trunc":
             rval = np.trunc(val)
-        elif method is None or method == '':
+        elif method is None or method == "":
             rval = val
         else:
-            raise ValueError('<{}> rounding method not valid!')
+            raise ValueError("<{}> rounding method not valid!")
         return rval
 
     def _run_callbacks(self, method):
         if self.callbacks:
             for cb in self.callbacks:
-                if hasattr(cb, method): getattr(cb, method)(self)
+                if hasattr(cb, method):
+                    getattr(cb, method)(self)
 
     # overloadings
 
@@ -1099,90 +1223,119 @@ class Fxp():
 
     def __bool__(self):
         if self.size > 1:
-            raise ValueError("The boolean value cannot be determined. Use any() or all().")
+            raise ValueError(
+                "The boolean value cannot be determined. Use any() or all()."
+            )
         else:
             return bool(self.get_val())
 
     def __int__(self):
         if self.size > 1:
-            raise TypeError('only length-1 arrays can be converted to Python scalars')
+            raise TypeError("only length-1 arrays can be converted to Python scalars")
         return int(self.astype(int))
 
     def __float__(self):
         if self.size > 1:
-            raise TypeError('only length-1 arrays can be converted to Python scalars')
+            raise TypeError("only length-1 arrays can be converted to Python scalars")
         return float(self.astype(float))
 
     def __complex__(self):
         if self.size > 1:
-            raise TypeError('only length-1 arrays can be converted to Python scalars')
+            raise TypeError("only length-1 arrays can be converted to Python scalars")
         return complex(self.astype(complex))
-    
+
     # representation
-    
+
     def __repr__(self):
         dtype_str = self.dtype
-        data_str = str(self.get_val()).replace('\n', '\n '+' '*(len(dtype_str)))
+        data_str = str(self.get_val()).replace("\n", "\n " + " " * (len(dtype_str)))
 
-        return '{}({})'.format(self.dtype, data_str)
+        return "{}({})".format(self.dtype, data_str)
 
     def __str__(self):
         return str(self.get_val())
 
     # numpy array representation - numpy hooks
-    
+
     def __array__(self, *args, **kwargs):
-        if self.config.array_op_method == 'raw':
+        if self.config.array_op_method == "raw":
             return np.asarray(self.val, *args, **kwargs)
         else:
             return np.asarray(self.get_val(), *args, **kwargs)
-    
-    def __array_wrap__(self, out_arr, context=None):
-        raw = True if self.config.array_op_method == 'raw' else False
 
-        if self.config.array_output_type == 'fxp':
+    def __array_wrap__(self, out_arr, context=None):
+        raw = True if self.config.array_op_method == "raw" else False
+
+        if self.config.array_output_type == "fxp":
             if self.config.array_op_out is not None:
                 return self.config.array_op_out.set_val(out_arr, raw=raw)
             elif self.config.array_op_out_like is not None:
-                return self.__class__(out_arr, like=self.config.array_op_out_like, raw=raw)
+                return self.__class__(
+                    out_arr, like=self.config.array_op_out_like, raw=raw
+                )
             else:
                 return self.__class__(out_arr)
         else:
             return out_arr
 
     def __array_prepare__(self, context=None, *args, **kwargs):
-        if self.config.array_op_method == 'raw':
+        if self.config.array_op_method == "raw":
             return np.asarray(self.val, *args, **kwargs)
         else:
             return np.asarray(self.get_val(), *args, **kwargs)
 
     def __array_finalize__(self, obj):
         return
-  
+
     # math operations
-    
+
     def __neg__(self):
-        y = Fxp(-self.val, signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
+        y = Fxp(
+            -self.val,
+            signed=self.signed,
+            n_word=self.n_word,
+            n_frac=self.n_frac,
+            raw=True,
+        )
         return y
 
     def __pos__(self):
-        y = Fxp(+self.val, signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
+        y = Fxp(
+            +self.val,
+            signed=self.signed,
+            n_word=self.n_word,
+            n_frac=self.n_frac,
+            raw=True,
+        )
         return y
 
     def __abs__(self):
-        y = Fxp(abs(self.val), signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
-        return y          
+        y = Fxp(
+            abs(self.val),
+            signed=self.signed,
+            n_word=self.n_word,
+            n_frac=self.n_frac,
+            raw=True,
+        )
+        return y
 
     def __add__(self, x):
         from .functions import add
-        
+
         if not isinstance(x, Fxp):
             x = self._convert_op_input_value(x)
             _sizing = self.config.const_op_sizing
         else:
             _sizing = self.config.op_sizing
 
-        return add(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return add(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __radd__ = __add__
 
@@ -1197,7 +1350,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return sub(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return sub(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     def __rsub__(self, x):
         from .functions import sub
@@ -1209,7 +1369,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return sub(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return sub(
+            x,
+            self,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __isub__ = __sub__
 
@@ -1222,7 +1389,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return mul(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return mul(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __rmul__ = __mul__
 
@@ -1237,7 +1411,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return truediv(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return truediv(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     def __rtruediv__(self, x):
         from .functions import truediv
@@ -1248,7 +1429,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return truediv(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return truediv(
+            x,
+            self,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __itruediv__ = __truediv__
 
@@ -1261,7 +1449,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return floordiv(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return floordiv(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     def __rfloordiv__(self, x):
         from .functions import floordiv
@@ -1272,7 +1467,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return floordiv(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return floordiv(
+            x,
+            self,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __ifloordiv__ = __floordiv__
 
@@ -1285,7 +1487,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return mod(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return mod(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     def __rmod__(self, x):
         from .functions import mod
@@ -1296,7 +1505,14 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return mod(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return mod(
+            x,
+            self,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __imod__ = __mod__
 
@@ -1309,25 +1525,39 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        return pow(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
+        return pow(
+            self,
+            x,
+            out=self.config.op_out,
+            out_like=self.config.op_out_like,
+            sizing=_sizing,
+            method=self.config.op_method,
+        )
 
     __rpow__ = __pow__
 
     __ipow__ = __pow__
 
-    
     # bit level operators
 
     def __rshift__(self, n):
-        if self.config.shifting == 'expand':
-            min_pow2 = utils.min_pow2(self.val)     # minimum power of 2 in raw val
+        if self.config.shifting == "expand":
+            min_pow2 = utils.min_pow2(self.val)  # minimum power of 2 in raw val
             if min_pow2 is not None and n > min_pow2:
                 n_frac_expansion = n - min_pow2
             else:
                 n_frac_expansion = 0
-            
-            y = Fxp(None, signed=self.signed, n_word=self.n_word+n_frac_expansion, n_frac=self.n_frac+n_frac_expansion)
-            y.set_val(self.val >> np.array(n - n_frac_expansion, dtype=self.val.dtype), raw=True)   # set raw val shifted
+
+            y = Fxp(
+                None,
+                signed=self.signed,
+                n_word=self.n_word + n_frac_expansion,
+                n_frac=self.n_frac + n_frac_expansion,
+            )
+            y.set_val(
+                self.val >> np.array(n - n_frac_expansion, dtype=self.val.dtype),
+                raw=True,
+            )  # set raw val shifted
         else:
             y = self.deepcopy()
             y.val = y.val >> np.array(n, dtype=y.val.dtype)
@@ -1336,15 +1566,35 @@ class Fxp():
     __irshift__ = __rshift__
 
     def __lshift__(self, n):
-        if self.config.shifting == 'expand':
-            n_word = max(self.n_word, int(np.max(np.ceil(np.log2(np.abs(self.val)+0.5)))) + self.signed + n)
+        if self.config.shifting == "expand":
+            n_word = max(
+                self.n_word,
+                int(np.max(np.ceil(np.log2(np.abs(self.val) + 0.5)))) + self.signed + n,
+            )
         else:
             n_word = self.n_word
 
         y = Fxp(None, signed=self.signed, n_word=n_word, n_frac=self.n_frac)
-        y.set_val(self.val << np.array(n, dtype=self.val.dtype), raw=True, vdtype=self.vdtype)   # set raw val shifted
+
+        if self.config.shifting == "keep":
+            a = self.val << np.array(n, dtype=self.val.dtype)
+            b = np.array((1 << n_word) - 1, dtype=self.val.dtype)
+            # this formatting is necessary for when shifting a 1 in a signed number 
+            # into the MSB. i.e. 1 << 7 == -128, not 127 
+            y.set_val(
+                f"0b{(a & b):0{n_word}b}", 
+                raw=True,
+                vdtype=self.vdtype,
+            )
+        else:
+            y.set_val(
+                self.val << np.array(n, dtype=self.val.dtype),
+                raw=True,
+                vdtype=self.vdtype,
+            )  # set raw val shifted
+
         return y
-    
+
     __ilshift__ = __lshift__
 
     def __invert__(self):
@@ -1353,9 +1603,9 @@ class Fxp():
         inverted_val = utils.binary_invert(self.val, n_word=self.n_word)
         if self.signed:
             inverted_val = utils.twos_complement_repr(inverted_val, nbits=self.n_word)
-        
+
         y = self.deepcopy()
-        y.set_val(inverted_val, raw=True, vdtype=self.vdtype)   # set raw val inverted
+        y.set_val(inverted_val, raw=True, vdtype=self.vdtype)  # set raw val inverted
         return y
 
     def __and__(self, x):
@@ -1363,7 +1613,9 @@ class Fxp():
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
+                x_val = x.val.astype(
+                    self.val.dtype
+                )  # if it doen't care data type difference
         else:
             x_val = x
 
@@ -1372,7 +1624,9 @@ class Fxp():
             added_val = utils.twos_complement_repr(added_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(added_val, raw=True, vdtype=self.vdtype)   # set raw val with AND operation  
+        y.set_val(
+            added_val, raw=True, vdtype=self.vdtype
+        )  # set raw val with AND operation
         return y
 
     __rand__ = __and__
@@ -1384,16 +1638,22 @@ class Fxp():
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
+                x_val = x.val.astype(
+                    self.val.dtype
+                )  # if it doen't care data type difference
         else:
             x_val = x
 
-        ored_val = utils.binary_or(self.val.astype(self.val.dtype), x_val, n_word=self.n_word)
+        ored_val = utils.binary_or(
+            self.val.astype(self.val.dtype), x_val, n_word=self.n_word
+        )
         if self.signed:
             ored_val = utils.twos_complement_repr(ored_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(ored_val, raw=True, vdtype=self.vdtype)   # set raw val with OR operation  
+        y.set_val(
+            ored_val, raw=True, vdtype=self.vdtype
+        )  # set raw val with OR operation
         return y
 
     __ror__ = __or__
@@ -1405,22 +1665,27 @@ class Fxp():
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
+                x_val = x.val.astype(
+                    self.val.dtype
+                )  # if it doen't care data type difference
         else:
             x_val = x
 
-        xored_val = utils.binary_xor(self.val.astype(self.val.dtype), x_val, n_word=self.n_word)
+        xored_val = utils.binary_xor(
+            self.val.astype(self.val.dtype), x_val, n_word=self.n_word
+        )
         if self.signed:
             xored_val = utils.twos_complement_repr(xored_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(xored_val, raw=True, vdtype=self.vdtype)   # set raw val with XOR operation  
-        return y  
+        y.set_val(
+            xored_val, raw=True, vdtype=self.vdtype
+        )  # set raw val with XOR operation
+        return y
 
     __rxor__ = __xor__
 
-    __ixor__ = __xor__    
-
+    __ixor__ = __xor__
 
     # comparisons
 
@@ -1470,35 +1735,34 @@ class Fxp():
         if format == dict:
             s = self.status
         elif format == str:
-            s = ''
+            s = ""
             for k, v in self.status.items():
                 if v:
-                    s += '\t{:<8}\t=\t{}\n'.format(k,v)
+                    s += "\t{:<8}\t=\t{}\n".format(k, v)
         return s
 
     def info(self, verbose=1):
-        s = ''
+        s = ""
         if verbose > 0:
-            s += '\tdtype\t\t=\t{}\n'.format(self.dtype)
-            s += '\tValue\t\t=\t' + self.__str__() + '\n'
+            s += "\tdtype\t\t=\t{}\n".format(self.dtype)
+            s += "\tValue\t\t=\t" + self.__str__() + "\n"
             if self.scaled:
-                s += '\tScaling\t\t=\t{} * val + {}\n'.format(self.scale, self.bias)
+                s += "\tScaling\t\t=\t{} * val + {}\n".format(self.scale, self.bias)
             s += self.get_status(format=str)
         if verbose > 1:
-            s += '\n\tSigned\t\t=\t{}\n'.format(self.signed)
-            s += '\tWord bits\t=\t{}\n'.format(self.n_word)
-            s += '\tFract bits\t=\t{}\n'.format(self.n_frac)
-            s += '\tInt bits\t=\t{}\n'.format(self.n_int)
-            s += '\tVal data type\t=\t{}\n'.format(self.vdtype)
+            s += "\n\tSigned\t\t=\t{}\n".format(self.signed)
+            s += "\tWord bits\t=\t{}\n".format(self.n_word)
+            s += "\tFract bits\t=\t{}\n".format(self.n_frac)
+            s += "\tInt bits\t=\t{}\n".format(self.n_int)
+            s += "\tVal data type\t=\t{}\n".format(self.vdtype)
         if verbose > 2:
-            s += '\n\tUpper\t\t=\t{}\n'.format(self.upper)
-            s += '\tLower\t\t=\t{}\n'.format(self.lower)
-            s += '\tPrecision\t=\t{}\n'.format(self.precision)
-            s += '\tOverflow\t=\t{}\n'.format(self.config.overflow)
-            s += '\tRounding\t=\t{}\n'.format(self.config.rounding)
-            s += '\tShifting\t=\t{}\n'.format(self.config.shifting)
+            s += "\n\tUpper\t\t=\t{}\n".format(self.upper)
+            s += "\tLower\t\t=\t{}\n".format(self.lower)
+            s += "\tPrecision\t=\t{}\n".format(self.precision)
+            s += "\tOverflow\t=\t{}\n".format(self.config.overflow)
+            s += "\tRounding\t=\t{}\n".format(self.config.rounding)
+            s += "\tShifting\t=\t{}\n".format(self.config.shifting)
         print(s)
-
 
     # base representations
     def bin(self, frac_dot=False):
@@ -1506,21 +1770,46 @@ class Fxp():
             n_frac_dot = self.n_frac
         else:
             n_frac_dot = None
-        
+
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [utils.binary_repr(utils.int_array(val.real), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
-                imag_val = [utils.binary_repr(utils.int_array(val.imag), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
+                real_val = [
+                    utils.binary_repr(
+                        utils.int_array(val.real), n_word=self.n_word, n_frac=n_frac_dot
+                    )
+                    for val in self.val
+                ]
+                imag_val = [
+                    utils.binary_repr(
+                        utils.int_array(val.imag), n_word=self.n_word, n_frac=n_frac_dot
+                    )
+                    for val in self.val
+                ]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [utils.binary_repr(utils.int_array(val), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
+                rval = [
+                    utils.binary_repr(
+                        utils.int_array(val), n_word=self.n_word, n_frac=n_frac_dot
+                    )
+                    for val in self.val
+                ]
         else:
             if self.vdtype == complex:
-                real_val = utils.binary_repr(utils.int_array(self.val.real), n_word=self.n_word, n_frac=n_frac_dot)
-                imag_val = utils.binary_repr(utils.int_array(self.val.imag), n_word=self.n_word, n_frac=n_frac_dot)
+                real_val = utils.binary_repr(
+                    utils.int_array(self.val.real),
+                    n_word=self.n_word,
+                    n_frac=n_frac_dot,
+                )
+                imag_val = utils.binary_repr(
+                    utils.int_array(self.val.imag),
+                    n_word=self.n_word,
+                    n_frac=n_frac_dot,
+                )
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = utils.binary_repr(int(self.val), n_word=self.n_word, n_frac=n_frac_dot)
+                rval = utils.binary_repr(
+                    int(self.val), n_word=self.n_word, n_frac=n_frac_dot
+                )
         return rval
 
     def hex(self, padding=True):
@@ -1531,20 +1820,52 @@ class Fxp():
 
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [utils.hex_repr(utils.binary_repr(utils.int_array(val.real), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2) for val in self.val]
-                imag_val = [utils.hex_repr(utils.binary_repr(utils.int_array(val.imag), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2) for val in self.val]
+                real_val = [
+                    utils.hex_repr(
+                        utils.binary_repr(
+                            utils.int_array(val.real), n_word=self.n_word, n_frac=None
+                        ),
+                        n_word=hex_n_word,
+                        base=2,
+                    )
+                    for val in self.val
+                ]
+                imag_val = [
+                    utils.hex_repr(
+                        utils.binary_repr(
+                            utils.int_array(val.imag), n_word=self.n_word, n_frac=None
+                        ),
+                        n_word=hex_n_word,
+                        base=2,
+                    )
+                    for val in self.val
+                ]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [utils.hex_repr(val, n_word=hex_n_word, base=2) for val in self.bin()]
+                rval = [
+                    utils.hex_repr(val, n_word=hex_n_word, base=2) for val in self.bin()
+                ]
         else:
             if self.vdtype == complex:
-                real_val = utils.hex_repr(utils.binary_repr(utils.int_array(self.val.real), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2)
-                imag_val = utils.hex_repr(utils.binary_repr(utils.int_array(self.val.imag), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2)
+                real_val = utils.hex_repr(
+                    utils.binary_repr(
+                        utils.int_array(self.val.real), n_word=self.n_word, n_frac=None
+                    ),
+                    n_word=hex_n_word,
+                    base=2,
+                )
+                imag_val = utils.hex_repr(
+                    utils.binary_repr(
+                        utils.int_array(self.val.imag), n_word=self.n_word, n_frac=None
+                    ),
+                    n_word=hex_n_word,
+                    base=2,
+                )
                 rval = utils.complex_repr(real_val, imag_val)
             else:
                 rval = utils.hex_repr(self.bin(), n_word=hex_n_word, base=2)
         return rval
-    
+
     def base_repr(self, base, frac_dot=False):
         if frac_dot:
             n_frac_dot = self.n_frac
@@ -1553,14 +1874,30 @@ class Fxp():
 
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [utils.base_repr(utils.int_array(val.real), base=base, n_frac=n_frac_dot)  for val in self.val]
-                imag_val = [utils.base_repr(utils.int_array(val.imag), base=base, n_frac=n_frac_dot)  for val in self.val]
+                real_val = [
+                    utils.base_repr(
+                        utils.int_array(val.real), base=base, n_frac=n_frac_dot
+                    )
+                    for val in self.val
+                ]
+                imag_val = [
+                    utils.base_repr(
+                        utils.int_array(val.imag), base=base, n_frac=n_frac_dot
+                    )
+                    for val in self.val
+                ]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [utils.base_repr(utils.int_array(val), base=base, n_frac=n_frac_dot) for val in self.val]
+                rval = [
+                    utils.base_repr(utils.int_array(val), base=base, n_frac=n_frac_dot)
+                    for val in self.val
+                ]
         else:
             if self.vdtype == complex:
-                rval = utils.complex_repr(utils.base_repr(int(self.val.real), base=base, n_frac=n_frac_dot), utils.base_repr(int(self.val.imag), base=base, n_frac=n_frac_dot))
+                rval = utils.complex_repr(
+                    utils.base_repr(int(self.val.real), base=base, n_frac=n_frac_dot),
+                    utils.base_repr(int(self.val.imag), base=base, n_frac=n_frac_dot),
+                )
             else:
                 rval = utils.base_repr(int(self.val), base=base, n_frac=n_frac_dot)
         return rval
@@ -1574,28 +1911,29 @@ class Fxp():
 
     def like(self, x):
         if isinstance(x, self.__class__):
-            new_raw_val = self.val * 2**(x.n_frac - self.n_frac)
-            return  x.copy().set_val(new_raw_val, raw=True)
+            new_raw_val = self.val * 2 ** (x.n_frac - self.n_frac)
+            return x.copy().set_val(new_raw_val, raw=True)
         else:
-            raise ValueError('`x` should be a Fxp object!')
+            raise ValueError("`x` should be a Fxp object!")
 
     # reset
     def reset(self):
-        #status (overwrite)
-        self.status = {
-            'overflow': False,
-            'underflow': False,
-            'inaccuracy': False}
+        # status (overwrite)
+        self.status = {"overflow": False, "underflow": False, "inaccuracy": False}
 
     def _convert_op_input_value(self, x):
         if not isinstance(x, Fxp):
             if self.config is not None:
-                if self.config.op_input_size == 'best':
+                if self.config.op_input_size == "best":
                     x_fxp = Fxp(x)
-                elif self.config.op_input_size == 'same':
+                elif self.config.op_input_size == "same":
                     x_fxp = Fxp(x, like=self)
                 else:
-                    raise ValueError('Sizing parameter not supported: {}'.format(self.config.op_input_size))
+                    raise ValueError(
+                        "Sizing parameter not supported: {}".format(
+                            self.config.op_input_size
+                        )
+                    )
             else:
                 x_fxp = Fxp(x)
         else:
@@ -1607,19 +1945,21 @@ class Fxp():
 
     # numpy functions dispatch
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        if method == '__call__':
+        if method == "__call__":
             if ufunc in _NUMPY_HANDLED_FUNCTIONS:
                 # dispatch function to implemented in fxpmath
-                return self._set_array_output_type(_NUMPY_HANDLED_FUNCTIONS[ufunc](*inputs, **kwargs))
+                return self._set_array_output_type(
+                    _NUMPY_HANDLED_FUNCTIONS[ufunc](*inputs, **kwargs)
+                )
 
             # call original numpy function and return wrapped result
-            kwargs['method'] = method
+            kwargs["method"] = method
             return self._wrapped_numpy_func(ufunc, *inputs, **kwargs)
         else:
             # return NotImplemented
 
             # call original numpy function and return wrapped result
-            kwargs['method'] = method
+            kwargs["method"] = method
             return self._wrapped_numpy_func(ufunc, *inputs, **kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
@@ -1633,42 +1973,50 @@ class Fxp():
         # __array_function__ to handle Fxp objects
         if not all(issubclass(t, self.__class__) for t in types):
             # return NotImplemented
-            pass    # delegates to implemented functions deal with conversion
+            pass  # delegates to implemented functions deal with conversion
 
         # dispatch function to implemented in fxpmath
-        return self._set_array_output_type(_NUMPY_HANDLED_FUNCTIONS[func](*args, **kwargs))
+        return self._set_array_output_type(
+            _NUMPY_HANDLED_FUNCTIONS[func](*args, **kwargs)
+        )
 
     def _wrapped_numpy_func(self, func, *args, **kwargs):
         # convert func inputs to numpy arrays
-        args = [np.asarray(arg) if isinstance(arg, self.__class__) else arg for arg in args]
+        args = [
+            np.asarray(arg) if isinstance(arg, self.__class__) else arg for arg in args
+        ]
 
         # out parameter extraction if Fxp
         out = None
-        if 'out' in kwargs:
-            if isinstance(kwargs['out'], self.__class__):
-                out = kwargs.pop('out', None)
-            elif (isinstance(kwargs['out'], tuple) and isinstance(kwargs['out'][0], self.__class__)):
-                out = kwargs.pop('out', None)[0]
+        if "out" in kwargs:
+            if isinstance(kwargs["out"], self.__class__):
+                out = kwargs.pop("out", None)
+            elif isinstance(kwargs["out"], tuple) and isinstance(
+                kwargs["out"][0], self.__class__
+            ):
+                out = kwargs.pop("out", None)[0]
             else:
                 out = None
-                kwargs.pop('out')
+                kwargs.pop("out")
 
         # out parameter extraction if Fxp
         out_like = None
-        if 'out_like' in kwargs:
-            if isinstance(kwargs['out_like'], self.__class__):
-                out_like = kwargs.pop('out_like', None)
-            elif (isinstance(kwargs['out_like'], tuple) and isinstance(kwargs['out_like'][0], self.__class__)):
-                out_like = kwargs.pop('out_like', None)
+        if "out_like" in kwargs:
+            if isinstance(kwargs["out_like"], self.__class__):
+                out_like = kwargs.pop("out_like", None)
+            elif isinstance(kwargs["out_like"], tuple) and isinstance(
+                kwargs["out_like"][0], self.__class__
+            ):
+                out_like = kwargs.pop("out_like", None)
             else:
                 out_like = None
-                kwargs.pop('out_like')
+                kwargs.pop("out_like")
 
         # get function if a method is specified
-        if 'method' in kwargs  and isinstance (kwargs['method'], str):
-            method = kwargs.pop('method')
+        if "method" in kwargs and isinstance(kwargs["method"], str):
+            method = kwargs.pop("method")
             func = getattr(func, method)
-            
+
         # calculate (call original numpy function)
         try:
             val = func(*args, **kwargs)
@@ -1697,21 +2045,24 @@ class Fxp():
             return self.__array_wrap__(val)
 
     def _set_array_output_type(self, out_arr):
-        if self.config._array_output_type == 'fxp':
-            raw = True if self.config.array_op_method == 'raw' else False
+        if self.config._array_output_type == "fxp":
+            raw = True if self.config.array_op_method == "raw" else False
 
             if self.config.array_op_out is not None:
                 return self.config.array_op_out.set_val(out_arr, raw=raw)
             elif self.config.array_op_out_like is not None:
-                return self.__class__(out_arr, like=self.config.array_op_out_like, raw=raw)
+                return self.__class__(
+                    out_arr, like=self.config.array_op_out_like, raw=raw
+                )
             elif not isinstance(out_arr, self.__class__):
                 return self.__class__(out_arr)
 
-        elif self.config._array_output_type == 'array' and isinstance(out_arr, self.__class__):
+        elif self.config._array_output_type == "array" and isinstance(
+            out_arr, self.__class__
+        ):
             return np.asarray(out_arr.get_val())
-        
-        return out_arr
 
+        return out_arr
 
     # methods derived from Numpy ndarray
 
@@ -1722,97 +2073,155 @@ class Fxp():
         return np.any(np.array(self), axis=axis, **kwargs)
 
     def argmax(self, axis=None, **kwargs):
-        return np.argmax(self.val, axis=axis, **kwargs)    # operates over raw values
+        return np.argmax(self.val, axis=axis, **kwargs)  # operates over raw values
 
     def argmin(self, axis=None, **kwargs):
-        return np.argmin(self.val, axis=axis, **kwargs)    # operates over raw values
+        return np.argmin(self.val, axis=axis, **kwargs)  # operates over raw values
 
     def argpartition(self, axis=-1, **kwargs):
-        return np.argpartition(self.val, axis=axis, **kwargs)    # operates over raw values
+        return np.argpartition(
+            self.val, axis=axis, **kwargs
+        )  # operates over raw values
 
     def argsort(self, axis=-1, **kwargs):
-        return np.argsort(self.val, axis=axis, **kwargs)    # operates over raw values
+        return np.argsort(self.val, axis=axis, **kwargs)  # operates over raw values
 
     def nonzero(self):
         from .functions import nonzero
-        return nonzero(self)  
+
+        return nonzero(self)
 
     def max(self, axis=None, **kwargs):
         from .functions import fxp_max
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return fxp_max(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return fxp_max(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def min(self, axis=None, **kwargs):
         from .functions import fxp_min
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return fxp_min(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return fxp_min(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def mean(self, axis=None, **kwargs):
-        if not 'out' in kwargs and \
-            self.config.array_output_type == 'fxp' and \
-            self.config.array_op_out is None and self.config.array_op_out_like is None: 
-            
-            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
+        if (
+            not "out" in kwargs
+            and self.config.array_output_type == "fxp"
+            and self.config.array_op_out is None
+            and self.config.array_op_out_like is None
+        ):
+
+            kwargs["out"] = Fxp(
+                like=self
+            )  # define Fxp output with same size by default
 
         return np.mean(self, axis=axis, **kwargs)
 
     def std(self, axis=None, **kwargs):
-        if not 'out' in kwargs and \
-            self.config.array_output_type == 'fxp' and \
-            self.config.array_op_out is None and self.config.array_op_out_like is None: 
-            
-            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
+        if (
+            not "out" in kwargs
+            and self.config.array_output_type == "fxp"
+            and self.config.array_op_out is None
+            and self.config.array_op_out_like is None
+        ):
+
+            kwargs["out"] = Fxp(
+                like=self
+            )  # define Fxp output with same size by default
 
         return np.std(self, axis=axis, **kwargs)
 
     def var(self, axis=None, **kwargs):
-        if not 'out' in kwargs and \
-            self.config.array_output_type == 'fxp' and \
-            self.config.array_op_out is None and self.config.array_op_out_like is None: 
-            
-            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
+        if (
+            not "out" in kwargs
+            and self.config.array_output_type == "fxp"
+            and self.config.array_op_out is None
+            and self.config.array_op_out_like is None
+        ):
+
+            kwargs["out"] = Fxp(
+                like=self
+            )  # define Fxp output with same size by default
 
         return np.var(self, axis=axis, **kwargs)
 
     def sum(self, axis=None, **kwargs):
         from .functions import sum
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return sum(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return sum(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def cumsum(self, axis=None, **kwargs):
         from .functions import cumsum
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return cumsum(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return cumsum(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def cumprod(self, axis=None, **kwargs):
         from .functions import cumprod
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return cumprod(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return cumprod(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     ravel = flatten
 
@@ -1825,12 +2234,14 @@ class Fxp():
     def conjugate(self, **kwargs):
         from .functions import conjugate
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return conjugate(self, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return conjugate(
+            self, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs
+        )
 
     conj = conjugate
 
@@ -1838,17 +2249,25 @@ class Fxp():
     def T(self):
         x = self.copy()
         x.val = x.val.T
-        return x    
-    
+        return x
+
     def transpose(self, axes=None, **kwargs):
         from .functions import transpose
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return transpose(self, axes=axes, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return transpose(
+            self,
+            axes=axes,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def item(self, *args):
         if len(args) > 1:
@@ -1863,42 +2282,79 @@ class Fxp():
     def clip(self, a_min=None, a_max=None, **kwargs):
         from .functions import clip
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return clip(self, a_min=a_min, a_max=a_max, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
+        return clip(
+            self,
+            a_min=a_min,
+            a_max=a_max,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def diagonal(self, offset=0, axis1=0, axis2=1, **kwargs):
         from .functions import diagonal
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return diagonal(self, offset=offset, axis1=axis1, axis2=axis2, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)  
+        return diagonal(
+            self,
+            offset=offset,
+            axis1=axis1,
+            axis2=axis2,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def trace(self, offset=0, axis1=0, axis2=1, **kwargs):
         from .functions import trace
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return trace(self, offset=offset, axis1=axis1, axis2=axis2, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
+        return trace(
+            self,
+            offset=offset,
+            axis1=axis1,
+            axis2=axis2,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def prod(self, axis=None, **kwargs):
         from .functions import prod
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', self.config.op_sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", self.config.op_sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return prod(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
+        return prod(
+            self,
+            axis=axis,
+            out=out,
+            out_like=out_like,
+            sizing=sizing,
+            method=method,
+            **kwargs,
+        )
 
     def dot(self, x, **kwargs):
         from .functions import dot
@@ -1909,50 +2365,54 @@ class Fxp():
         else:
             _sizing = self.config.op_sizing
 
-        out = kwargs.pop('out', self.config.op_out)
-        out_like = kwargs.pop('out_like', self.config.op_out_like)
-        sizing = kwargs.pop('sizing', _sizing)
-        method = kwargs.pop('method', self.config.op_method)
+        out = kwargs.pop("out", self.config.op_out)
+        out_like = kwargs.pop("out_like", self.config.op_out_like)
+        sizing = kwargs.pop("sizing", _sizing)
+        method = kwargs.pop("method", self.config.op_method)
 
-        return dot(self, x, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
+        return dot(
+            self, x, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs
+        )
 
-class Config():
+
+class Config:
     template = None
 
     def __init__(self, **kwargs):
         # size limits
-        self.max_error = kwargs.pop('max_error', 1 / 2**63)
-        self.n_word_max = kwargs.pop('n_word_max', 64)
+        self.max_error = kwargs.pop("max_error", 1 / 2**63)
+        self.n_word_max = kwargs.pop("n_word_max", 64)
 
         # behavior
-        self.overflow = kwargs.pop('overflow', 'saturate')
-        self.rounding = kwargs.pop('rounding', 'trunc')
-        self.shifting = kwargs.pop('shifting', 'expand')
-        self.op_method = kwargs.pop('op_method', 'raw')
+        self.overflow = kwargs.pop("overflow", "saturate")
+        self.rounding = kwargs.pop("rounding", "trunc")
+        self.shifting = kwargs.pop("shifting", "expand")
+        self.op_method = kwargs.pop("op_method", "raw")
 
         # inputs
-        self.op_input_size = kwargs.pop('op_input_size', 'same')
+        self.op_input_size = kwargs.pop("op_input_size", "same")
 
         # alu ops outpus
-        self.op_out = kwargs.pop('op_out', None)
-        self.op_out_like = kwargs.pop('op_out_like', None)
-        self.op_sizing = kwargs.pop('op_sizing', 'optimal')
+        self.op_out = kwargs.pop("op_out", None)
+        self.op_out_like = kwargs.pop("op_out_like", None)
+        self.op_sizing = kwargs.pop("op_sizing", "optimal")
 
         # alu ops with a constant operand
-        self.const_op_sizing = kwargs.pop('const_op_sizing', 'same')
+        self.const_op_sizing = kwargs.pop("const_op_sizing", "same")
 
         # array ops
-        self.array_output_type = kwargs.pop('array_output_type', 'fxp')
-        self.array_op_out = kwargs.pop('array_op_out', None)
-        self.array_op_out_like = kwargs.pop('array_op_out_like', None)
-        self.array_op_method = kwargs.pop('array_op_method', 'repr')
+        self.array_output_type = kwargs.pop("array_output_type", "fxp")
+        self.array_op_out = kwargs.pop("array_op_out", None)
+        self.array_op_out_like = kwargs.pop("array_op_out_like", None)
+        self.array_op_method = kwargs.pop("array_op_method", "repr")
 
         # notation
-        self.dtype_notation = kwargs.pop('dtype_notation', 'fxp')
+        self.dtype_notation = kwargs.pop("dtype_notation", "fxp")
 
         # update from template
         # if `template` is in kwarg, the reference template is updated
-        if 'template' in kwargs: self.template = kwargs.pop('template')
+        if "template" in kwargs:
+            self.template = kwargs.pop("template")
 
         if self.template is not None:
             if isinstance(self.template, Config):
@@ -1967,234 +2427,273 @@ class Config():
     @property
     def max_error(self):
         return self._max_error
-    
+
     @max_error.setter
     def max_error(self, val):
         if val > 0:
             self._max_error = val
         else:
-            raise ValueError('max_error must be greater than 0!')
+            raise ValueError("max_error must be greater than 0!")
 
     # n_word_max
     @property
     def n_word_max(self):
         return self._n_word_max
-    
+
     @n_word_max.setter
     def n_word_max(self, val):
         if isinstance(val, int) and val > 0:
             self._n_word_max = val
         else:
-            raise ValueError('n_word_max must be int type greater than 0!')
+            raise ValueError("n_word_max must be int type greater than 0!")
 
     # overflow
     @property
     def _overflow_list(self):
-        return ['saturate', 'wrap']
+        return ["saturate", "wrap"]
 
     @property
     def overflow(self):
         return self._overflow
-    
+
     @overflow.setter
     def overflow(self, val):
         if isinstance(val, str) and val in self._overflow_list:
             self._overflow = val
         else:
-            raise ValueError('overflow must be str type with following valid values: {}'.format(self._overflow_list))
+            raise ValueError(
+                "overflow must be str type with following valid values: {}".format(
+                    self._overflow_list
+                )
+            )
 
     # rounding
     @property
     def _rounding_list(self):
-        return ['around', 'floor', 'ceil', 'fix', 'trunc']
+        return ["around", "floor", "ceil", "fix", "trunc"]
 
     @property
     def rounding(self):
         return self._rounding
-    
+
     @rounding.setter
     def rounding(self, val):
         if isinstance(val, str) and val in self._rounding_list:
             self._rounding = val
         else:
-            raise ValueError('rounding must be str type with following valid values: {}'.format(self._rounding_list))
+            raise ValueError(
+                "rounding must be str type with following valid values: {}".format(
+                    self._rounding_list
+                )
+            )
 
     # shifting
     @property
     def _shifting_list(self):
-        return ['expand', 'trunc', 'keep']
+        return ["expand", "trunc", "keep"]
 
     @property
     def shifting(self):
         return self._shifting
-    
+
     @shifting.setter
     def shifting(self, val):
         if isinstance(val, str) and val in self._shifting_list:
             self._shifting = val
         else:
-            raise ValueError('shifting must be str type with following valid values: {}'.format(self._shifting_list))
+            raise ValueError(
+                "shifting must be str type with following valid values: {}".format(
+                    self._shifting_list
+                )
+            )
 
     # op_input_size
     @property
     def _op_input_size_list(self):
-        return ['same', 'best']
+        return ["same", "best"]
 
     @property
     def op_input_size(self):
         return self._op_input_size
-    
+
     @op_input_size.setter
     def op_input_size(self, val):
         if isinstance(val, str) and val in self._op_input_size_list:
             self._op_input_size = val
         else:
-            raise ValueError('op_input_size must be str type with following valid values: {}'.format(self._op_input_size_list))
-    
+            raise ValueError(
+                "op_input_size must be str type with following valid values: {}".format(
+                    self._op_input_size_list
+                )
+            )
 
     # op_out
     @property
     def op_out(self):
         return self._op_out
-    
+
     @op_out.setter
     def op_out(self, val):
         if val is None or isinstance(val, Fxp):
             self._op_out = val
         else:
-            raise ValueError('op_out must be a Fxp object or None!')
+            raise ValueError("op_out must be a Fxp object or None!")
 
     # op_out_like
     @property
     def op_out_like(self):
         return self._op_out_like
-    
+
     @op_out_like.setter
     def op_out_like(self, val):
         if val is None or isinstance(val, Fxp):
             self._op_out_like = val
         else:
-            raise ValueError('op_out_like must be a Fxp object or None!')
+            raise ValueError("op_out_like must be a Fxp object or None!")
 
     # op_sizing
     @property
     def _op_sizing_list(self):
-        return ['optimal', 'same', 'fit', 'largest', 'smallest']
+        return ["optimal", "same", "fit", "largest", "smallest"]
 
     @property
     def op_sizing(self):
         return self._op_sizing
-    
+
     @op_sizing.setter
     def op_sizing(self, val):
         if isinstance(val, str) and val in self._op_sizing_list:
             self._op_sizing = val
         else:
-            raise ValueError('op_sizing must be str type with following valid values: {}'.format(self._op_sizing_list))
+            raise ValueError(
+                "op_sizing must be str type with following valid values: {}".format(
+                    self._op_sizing_list
+                )
+            )
 
     # op_method
     @property
     def _op_method_list(self):
-        return ['raw', 'repr']
+        return ["raw", "repr"]
 
     @property
     def op_method(self):
         return self._op_method
-    
+
     @op_method.setter
     def op_method(self, val):
         if isinstance(val, str) and val in self._op_method_list:
             self._op_method = val
         else:
-            raise ValueError('op_method must be str type with following valid values: {}'.format(self._op_method_list))
+            raise ValueError(
+                "op_method must be str type with following valid values: {}".format(
+                    self._op_method_list
+                )
+            )
 
     # const_op_sizing
     @property
     def _const_op_sizing_list(self):
-        return ['optimal', 'same', 'fit', 'largest', 'smallest']
+        return ["optimal", "same", "fit", "largest", "smallest"]
 
     @property
     def const_op_sizing(self):
         return self._const_op_sizing
-    
+
     @const_op_sizing.setter
     def const_op_sizing(self, val):
         if isinstance(val, str) and val in self._const_op_sizing_list:
             self._const_op_sizing = val
         else:
-            raise ValueError('op_sizing must be str type with following valid values: {}'.format(self._const_op_sizing_list))
+            raise ValueError(
+                "op_sizing must be str type with following valid values: {}".format(
+                    self._const_op_sizing_list
+                )
+            )
 
     # array_output_type
     @property
     def _array_output_type_list(self):
-        return ['fxp', 'array']
+        return ["fxp", "array"]
 
     @property
     def array_output_type(self):
         return self._array_output_type
-    
+
     @array_output_type.setter
     def array_output_type(self, val):
         if isinstance(val, str) and val in self._array_output_type_list:
             self._array_output_type = val
         else:
-            raise ValueError('array_output_type must be str type with following valid values: {}'.format(self._array_output_type_list))
+            raise ValueError(
+                "array_output_type must be str type with following valid values: {}".format(
+                    self._array_output_type_list
+                )
+            )
 
     # array_op_out
     @property
     def array_op_out(self):
         return self._array_op_out
-    
+
     @array_op_out.setter
     def array_op_out(self, val):
         if val is None or isinstance(val, Fxp):
             self._array_op_out = val
         else:
-            raise ValueError('array_op_out must be a Fxp object or None!')
+            raise ValueError("array_op_out must be a Fxp object or None!")
 
     # array_op_out_like
     @property
     def array_op_out_like(self):
         return self._array_op_out_like
-    
+
     @array_op_out_like.setter
     def array_op_out_like(self, val):
         if val is None or isinstance(val, Fxp):
             self._array_op_out_like = val
         else:
-            raise ValueError('array_op_out_like must be a Fxp object or None!')
+            raise ValueError("array_op_out_like must be a Fxp object or None!")
 
     # array_op_method
     @property
     def _array_op_method_list(self):
-        return ['raw', 'repr']
+        return ["raw", "repr"]
 
     @property
     def array_op_method(self):
         return self._array_op_method
-    
+
     @array_op_method.setter
     def array_op_method(self, val):
         if isinstance(val, str) and val in self._array_op_method_list:
             self._array_op_method = val
         else:
-            raise ValueError('array_op_method must be str type with following valid values: {}'.format(self._array_op_method_list))
+            raise ValueError(
+                "array_op_method must be str type with following valid values: {}".format(
+                    self._array_op_method_list
+                )
+            )
 
     # dtype_notation
     @property
     def _dtype_notation_list(self):
-        return ['fxp', 'Q']
+        return ["fxp", "Q"]
 
     @property
     def dtype_notation(self):
         return self._dtype_notation
-    
+
     @dtype_notation.setter
     def dtype_notation(self, val):
         if isinstance(val, str) and val in self._dtype_notation_list:
             self._dtype_notation = val
         else:
-            raise ValueError('dtype_notation must be str type with following valid values: {}'.format(self._dtype_notation_list))
+            raise ValueError(
+                "dtype_notation must be str type with following valid values: {}".format(
+                    self._dtype_notation_list
+                )
+            )
 
     # endregion
 
@@ -2205,7 +2704,7 @@ class Config():
 
     def print(self):
         for k, v in self.__dict__.items():
-            print('\t{: <24}:\t{}'.format(k.strip('_'), v))
+            print("\t{: <24}:\t{}".format(k.strip("_"), v))
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -2218,15 +2717,19 @@ class Config():
 
     def deepcopy(self):
         return copy.deepcopy(self)
+
     # endregion
+
 
 # ----------------------------------------------------------------------------------------
 # Internal functions
 # ----------------------------------------------------------------------------------------
 def implements(*np_functions):
-   "Register an __array_function__ implementation for Fxp objects."
-   def decorator(fxp_func):
+    "Register an __array_function__ implementation for Fxp objects."
+
+    def decorator(fxp_func):
         for np_func in np_functions:
             _NUMPY_HANDLED_FUNCTIONS[np_func] = fxp_func
         return fxp_func
-   return decorator
+
+    return decorator

--- a/fxpmath/objects.py
+++ b/fxpmath/objects.py
@@ -32,8 +32,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-# %%
-import numpy as np
+#%% 
+import numpy as np 
 import math
 import copy
 import re
@@ -49,10 +49,9 @@ try:
 except:
     Decimal = type(None)
 
-
-# %%
-class Fxp:
-    """
+#%%
+class Fxp():
+    '''
     Numerical Fractional Fixed-Point object (base 2).
 
     Parameters
@@ -60,7 +59,7 @@ class Fxp:
 
     val : None, int, float, complex, list of numbers, numpy array, str (bin, hex, dec), optional, default=None
         Value(s) to be stored in fractional fixed-point (base 2) format.
-
+    
     signed : bool, optional, default=None
         If True, a sign bit is used for the binary word. If None, Fxp is signed.
 
@@ -78,7 +77,7 @@ class Fxp:
 
     like : Fxp, optional, default=None
         Init new Fxp object using all parameters of `like` Fxp object, except its value.
-
+        
     dtype : str, optional, default=None
         String describing the desired fixed-point format in either Q/UQ, S/U, or fxp dtype format.
 
@@ -129,26 +128,16 @@ class Fxp:
     callbacks : list
         List of callbacks.
 
-    """
+    '''
 
     template = None
 
-    def __init__(
-        self,
-        val=None,
-        signed=None,
-        n_word=None,
-        n_frac=None,
-        n_int=None,
-        like=None,
-        dtype=None,
-        **kwargs,
-    ):
+    def __init__(self, val=None, signed=None, n_word=None, n_frac=None, n_int=None, like=None, dtype=None, **kwargs):
 
         # Init all properties in None
-        self._dtype = "fxp"  # fxp-<sign><n_word>/<n_frac>-{complex}. i.e.: fxp-s16/15, fxp-u8/1, fxp-s32/24-complex
+        self._dtype = 'fxp' # fxp-<sign><n_word>/<n_frac>-{complex}. i.e.: fxp-s16/15, fxp-u8/1, fxp-s32/24-complex
         # value
-        self.vdtype = None  # value(s) dtype to return as default
+        self.vdtype = None # value(s) dtype to return as default
         self.val = None
         self.real = None
         self.imag = None
@@ -166,10 +155,10 @@ class Fxp:
         self.upper = None
         self.lower = None
         self.precision = None
-        # status
+        #status
         self.status = None
         self.callbacks = None
-        # config
+        #config
         self.config = None
 
         _initialized = False
@@ -179,8 +168,7 @@ class Fxp:
         self.config = Config()
 
         # if `template` is in kwarg, the reference template is updated
-        if "template" in kwargs:
-            self.template = kwargs.pop("template")
+        if 'template' in kwargs: self.template = kwargs.pop('template')
 
         # check if init must be a `like` other Fxp
         if like is not None:
@@ -200,39 +188,34 @@ class Fxp:
                 self.imag = None
                 _initialized = True
 
-        # status (overwrite)
+        #status (overwrite)
         self.status = {
-            "overflow": False,
-            "underflow": False,
-            "inaccuracy": False,
-            "extended_prec": False,
-        }
+            'overflow': False,
+            'underflow': False,
+            'inaccuracy': False,
+            'extended_prec': False}
 
         # update config as argument
-        _config = kwargs.pop("config", None)
+        _config = kwargs.pop('config', None)
         if _config is not None:
             if isinstance(_config, Config):
                 self.config = _config.deepcopy()
             else:
-                raise TypeError("config parameter must be Config class type!")
+                raise TypeError('config parameter must be Config class type!')
 
         # update config from kwargs
         self.config.update(**kwargs)
 
         # callbacks
-        if self.callbacks is None:
-            self.callbacks = kwargs.pop("callbacks", [])
+        if self.callbacks is None: self.callbacks = kwargs.pop('callbacks', [])
 
         # scaling
-        if self.scale is None:
-            self.scale = kwargs.pop("scale", 1)
-        if self.bias is None:
-            self.bias = kwargs.pop("bias", 0)
+        if self.scale is None: self.scale = kwargs.pop('scale', 1)
+        if self.bias is None: self.bias = kwargs.pop('bias', 0)
         self.scaled = True if self.scale != 1 or self.bias != 0 else False
 
         # check if val is a raw value
-        if raw is None:
-            raw = kwargs.pop("raw", False)
+        if raw is None: raw = kwargs.pop('raw', False)
 
         # check if a string-based format has been provided
         if dtype is not None:
@@ -242,16 +225,7 @@ class Fxp:
 
         # size
         if not _initialized:
-            self._init_size(
-                val,
-                signed,
-                n_word,
-                n_frac,
-                n_int,
-                max_error=self.config.max_error,
-                n_word_max=self.config.n_word_max,
-                raw=raw,
-            )
+            self._init_size(val, signed, n_word, n_frac, n_int, max_error=self.config.max_error, n_word_max=self.config.n_word_max, raw=raw)
         else:
             # overwrite with other sizes if some are not None
             self.resize(signed, n_word, n_frac, n_int)
@@ -275,7 +249,7 @@ class Fxp:
     @property
     def overflow(self):
         return self.config.overflow
-
+    
     @overflow.setter
     def overflow(self, val):
         self.config.overflow = val
@@ -284,7 +258,7 @@ class Fxp:
     @property
     def rounding(self):
         return self.config.rounding
-
+    
     @rounding.setter
     def rounding(self, val):
         self.config.rounding = val
@@ -293,7 +267,7 @@ class Fxp:
     @property
     def shifting(self):
         return self.config.shifting
-
+    
     @shifting.setter
     def shifting(self, val):
         self.config.shifting = val
@@ -309,6 +283,7 @@ class Fxp:
     @property
     def size(self):
         return self.val.size
+
 
     # endregion
 
@@ -337,19 +312,19 @@ class Fxp:
             String describing the fixed-point format in either Q/UQ, S/U, or fxp dtype format (default).
 
         """
-        self._update_dtype(notation)  # update dtype
+        self._update_dtype(notation)    # update dtype
         return self._dtype
-
-    _qfmt = re.compile(r"(s|u|q|uq|qu)(\d+)(\.\d+)?")
-    _fxpfmt = re.compile(r"fxp-(s|u)(\d+)/(\d+)(-complex)?")
-
+    
+    _qfmt   = re.compile(r'(s|u|q|uq|qu)(\d+)(\.\d+)?')
+    _fxpfmt = re.compile(r'fxp-(s|u)(\d+)/(\d+)(-complex)?')
+    
     def _parseformatstr(self, fmt):
         fmt = fmt.casefold()
         mo = self._qfmt.match(fmt)
         if mo:
             # Q/S notation counts the sign bit as an integer bit, such that
             # the total number of bits is always int+frac
-            signed = mo.group(1) in "sq"
+            signed = mo.group(1) in 'sq'
             n_int = int(mo.group(2))
             if mo.group(3) is None:
                 n_frac = 0
@@ -360,36 +335,26 @@ class Fxp:
         else:
             mo = self._fxpfmt.match(fmt)
             if mo:
-                signed = mo.group(1) == "s"
+                signed = mo.group(1) == 's'
                 n_word = int(mo.group(2))
                 n_frac = int(mo.group(3))
                 complex_dtype = False
                 if mo.lastindex > 3:
                     _complex_str = str(mo.group(4))
-                    if _complex_str == "-complex":
+                    if _complex_str == '-complex':
                         complex_dtype = True
-
+                        
             else:
-                raise ValueError("unrecognized format string")
+                raise ValueError('unrecognized format string')
         return signed, n_word, n_frac, complex_dtype
-
-    def _init_size(
-        self,
-        val=None,
-        signed=None,
-        n_word=None,
-        n_frac=None,
-        n_int=None,
-        max_error=_max_error,
-        n_word_max=_n_word_max,
-        raw=False,
-    ):
+    
+    def _init_size(self, val=None, signed=None, n_word=None, n_frac=None, n_int=None, max_error=_max_error, n_word_max=_n_word_max, raw=False):
         # sign by default
         if signed is None:
             self.signed = True
         else:
             self.signed = signed
-
+        
         # n_int defined:
         if n_word is None and n_frac is not None and n_int is not None:
             n_word = n_int + n_frac + (1 if self.signed else 0)
@@ -398,21 +363,11 @@ class Fxp:
 
         # check if I must find the best size for val
         if n_word is None or n_frac is None:
-            self.set_best_sizes(
-                val, n_word, n_frac, max_error=max_error, n_word_max=n_word_max, raw=raw
-            )
+            self.set_best_sizes(val, n_word, n_frac, max_error=max_error, n_word_max=n_word_max, raw=raw)
         else:
             self.resize(self.signed, n_word, n_frac, n_int)
 
-    def resize(
-        self,
-        signed=None,
-        n_word=None,
-        n_frac=None,
-        n_int=None,
-        restore_val=True,
-        dtype=None,
-    ):
+    def resize(self, signed=None, n_word=None, n_frac=None, n_int=None, restore_val=True, dtype=None):
         """
         Change size of one or more of size parameters (signed, n_word, n_int and/or n_frac) of the Fxp object.
 
@@ -446,15 +401,8 @@ class Fxp:
 
         # check if a string-based format has been provided
         if dtype is not None:
-            if (
-                signed is not None
-                or n_word is not None
-                or n_frac is not None
-                or n_int is not None
-            ):
-                raise ValueError(
-                    "If dtype is specified, other sizing parameters must be `None`!"
-                )
+            if signed is not None or n_word is not None or n_frac is not None or n_int is not None:
+                raise ValueError('If dtype is specified, other sizing parameters must be `None`!')
             signed, n_word, n_frac, complex_flag = self._parseformatstr(dtype)
 
             self.vdtype = complex if complex_flag else self.vdtype
@@ -474,23 +422,23 @@ class Fxp:
         # frac
         if n_frac is not None:
             self.n_frac = n_frac
-
-        # n_int
+    
+        # n_int    
         self.n_int = self.n_word - self.n_frac - (1 if self.signed else 0)
 
         # status extended precision
         if self.n_word >= _n_word_max:
-            self.status["extended_prec"] = True
+            self.status['extended_prec'] = True
         else:
-            self.status["extended_prec"] = False
+            self.status['extended_prec'] = False
 
         # upper and lower limits
         if self.signed:
-            upper_val = (1 << (self.n_word - 1)) - 1
+            upper_val = (1 << (self.n_word-1)) - 1
             lower_val = -upper_val - 1
         else:
-            upper_val = (1 << self.n_word) - 1
-            lower_val = 0
+            upper_val =  (1 << self.n_word) - 1
+            lower_val = 0 
 
         if self.vdtype == complex:
             self.upper = (upper_val + 1j * upper_val) / 2.0**self.n_frac
@@ -512,22 +460,14 @@ class Fxp:
             if self.scaled:
                 self.set_val((_old_val / 2**_old_n_frac) * self.scale + self.bias)
             else:
-                self.set_val(_old_val * 2 ** (self.n_frac - _old_n_frac), raw=True)
+                self.set_val(_old_val * 2**(self.n_frac - _old_n_frac), raw=True)
         else:
             self.set_val(_old_val, raw=True)
 
         # update dtype
         self._update_dtype()
-
-    def set_best_sizes(
-        self,
-        val=None,
-        n_word=None,
-        n_frac=None,
-        max_error=1.0e-6,
-        n_word_max=64,
-        raw=False,
-    ):
+    
+    def set_best_sizes(self, val=None, n_word=None, n_frac=None, max_error=1.0e-6, n_word_max=64, raw=False):
 
         if val is None:
             if n_word is None and n_frac is None:
@@ -547,11 +487,9 @@ class Fxp:
 
             self.n_word = n_word
             self.n_frac = n_frac
-
+            
             # if val is a str(s), convert to number(s)
-            val, _, raw, signed, n_word, n_frac = self._format_inupt_val(
-                val, return_sizes=True, raw=raw
-            )
+            val, _, raw, signed, n_word, n_frac = self._format_inupt_val(val, return_sizes=True, raw=raw)
             val = np.array([val])
 
             # check if val is complex, if it is: convert to array of float/int
@@ -559,13 +497,13 @@ class Fxp:
                 val_real = np.vectorize(lambda v: v.real)(val)
                 val_imag = np.vectorize(lambda v: v.imag)(val)
                 val = np.array([val_real, val_imag])
-
+            
             # if val is raw
             if raw:
                 if self.n_frac is not None:
                     val = val / self._get_conv_factor()
                 else:
-                    raise ValueError("for raw value, `n_frac` must be defined!")
+                    raise ValueError('for raw value, `n_frac` must be defined!')
 
             # define numpy integer type
             if self.signed:
@@ -574,7 +512,7 @@ class Fxp:
                 int_dtype = np.uint64
 
             # find fractional parts
-            frac_vals = np.abs(val % 1).ravel()
+            frac_vals = np.abs(val%1).ravel()
 
             # n_frac estimation
             if n_frac is None:
@@ -595,9 +533,9 @@ class Fxp:
 
             # max raw value (integer) estimation
             # n_int = max( np.ceil(np.log2(np.max(np.abs( val*(1 << n_frac) + 0.5 )))).astype(int_dtype) - n_frac, 0)
-
-            val_max = int(np.max(val) * (1 << n_frac))
-            val_min = int(np.min(val) * (1 << n_frac))
+            
+            val_max = int(np.max(val)*(1 << n_frac))
+            val_min = int(np.min(val)*(1 << n_frac))
             n_int = 0
             while n_int < n_word_max - sign:
                 msb_max = (val_max >> n_int) + (1 if val_max < 0 else 0)
@@ -611,34 +549,32 @@ class Fxp:
 
             # size assignement
             if n_word is None:
-                n_frac = min(
-                    n_word_max - sign - n_int, n_frac
-                )  # n_frac limit according n_word max size
+                n_frac = min(n_word_max - sign - n_int, n_frac) # n_frac limit according n_word max size
                 self.n_frac = int(n_frac)
                 self.n_word = int(n_frac + n_int + sign)
             else:
                 self.n_word = int(n_word)
                 self.n_frac = n_frac = int(min(n_word - sign - n_int, n_frac))
-
+        
         self.n_word = int(min(self.n_word, n_word_max))
         self.resize(restore_val=False)
 
-    def reshape(self, shape, order="C"):
+    def reshape(self, shape, order='C'):
         """
         Reshape the fixed-point array.
 
         Parameters
         ---
         shape : int or tuple of ints
-            The new shape should be compatible with the original shape.
-            If an integer, then the result will be a 1-D array of that length.
+            The new shape should be compatible with the original shape. 
+            If an integer, then the result will be a 1-D array of that length. 
             One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.
 
         order : {‘C’, ‘F’, ‘A’}, optional
-            Read the elements of a using this index order, and place the elements into the reshaped array using this index order.
-            ‘C’ means to read / write the elements using C-like index order, with the last axis index changing fastest, back to the first axis index changing slowest.
-            ‘F’ means to read / write the elements using Fortran-like index order, with the first index changing fastest, and the last index changing slowest.
-            Note that the ‘C’ and ‘F’ options take no account of the memory layout of the underlying array, and only refer to the order of indexing.
+            Read the elements of a using this index order, and place the elements into the reshaped array using this index order. 
+            ‘C’ means to read / write the elements using C-like index order, with the last axis index changing fastest, back to the first axis index changing slowest. 
+            ‘F’ means to read / write the elements using Fortran-like index order, with the first index changing fastest, and the last index changing slowest. 
+            Note that the ‘C’ and ‘F’ options take no account of the memory layout of the underlying array, and only refer to the order of indexing. 
             ‘A’ means to read / write the elements in Fortran-like index order if a is Fortran contiguous in memory, C-like order otherwise.
 
         Returns
@@ -647,11 +583,11 @@ class Fxp:
             Same Fxp object with its reshaped values array.
 
         """
-
+        
         self.val = self.val.reshape(shape=shape, order=order)
         return self
-
-    def flatten(self, order="C"):
+    
+    def flatten(self, order='C'):
         """
         Return a copy of the Fxp with its values array collapsed into one dimension.
 
@@ -659,10 +595,10 @@ class Fxp:
         ---
 
         order{‘C’, ‘F’, ‘A’, ‘K’}, optional
-            ‘C’ means to flatten in row-major (C-style) order.
-            ‘F’ means to flatten in column-major (Fortran- style) order.
-            ‘A’ means to flatten in column-major order if a is Fortran contiguous in memory, row-major order otherwise.
-            ‘K’ means to flatten a in the order the elements occur in memory.
+            ‘C’ means to flatten in row-major (C-style) order. 
+            ‘F’ means to flatten in column-major (Fortran- style) order. 
+            ‘A’ means to flatten in column-major order if a is Fortran contiguous in memory, row-major order otherwise. 
+            ‘K’ means to flatten a in the order the elements occur in memory. 
             The default is ‘C’.
 
         Returns
@@ -696,14 +632,11 @@ class Fxp:
             # if val is an Fxp object
             vdtype = val.vdtype
             # if some of signed, n_word, n_frac is not defined, they are copied from val
-            if self.signed is None:
-                self.signed = val.signed
-            if self.n_word is None:
-                self.n_word = val.n_word
-            if self.n_frac is None:
-                self.n_frac = val.n_frac
+            if self.signed is None: self.signed = val.signed
+            if self.n_word is None: self.n_word = val.n_word
+            if self.n_frac is None: self.n_frac = val.n_frac
             # force return raw value for better precision
-            val = val.val * 2 ** (self.n_frac - val.n_frac)
+            val = val.val * 2**(self.n_frac - val.n_frac)
             raw = True
 
         elif isinstance(val, (int, float, complex)):
@@ -714,7 +647,7 @@ class Fxp:
                 vdtype = type(val.item(0))
             else:
                 vdtype = val.dtype
-
+            
             try:
                 if isinstance(val, np.float128):
                     val = np.array(float(val))
@@ -727,13 +660,9 @@ class Fxp:
                 val = val.tolist()
 
                 if not raw:
-                    val, signed, n_word, n_frac = utils.str2num(
-                        val, self.signed, self.n_word, self.n_frac, return_sizes=True
-                    )
+                    val, signed, n_word, n_frac = utils.str2num(val, self.signed, self.n_word, self.n_frac, return_sizes=True)
                 else:
-                    val, signed, n_word, _ = utils.str2num(
-                        val, self.signed, self.n_word, None, return_sizes=True
-                    )
+                    val, signed, n_word, _ = utils.str2num(val, self.signed, self.n_word, None, return_sizes=True)
                     n_frac = self.n_frac
 
                 if n_frac is not None and n_frac == 0:
@@ -744,37 +673,32 @@ class Fxp:
         elif isinstance(val, (list, tuple, str)):
             # if val is a str(s), convert to number(s)
             if not raw:
-                val, signed, n_word, n_frac = utils.str2num(
-                    val, self.signed, self.n_word, self.n_frac, return_sizes=True
-                )
+                val, signed, n_word, n_frac = utils.str2num(val, self.signed, self.n_word, self.n_frac, return_sizes=True)
             else:
-                val, signed, n_word, _ = utils.str2num(
-                    val, self.signed, self.n_word, None, return_sizes=True
-                )
+                val, signed, n_word, _ = utils.str2num(val, self.signed, self.n_word, None, return_sizes=True)
                 n_frac = self.n_frac
 
         elif isinstance(val, Decimal):
-            vdtype = float  # assuming float format
+            vdtype = float            # assuming float format
 
             if self.n_frac is None:
                 # estimate n_frac from decimal precision
-                self.n_frac = n_frac = int(
-                    np.ceil(math.log2(10 ** int(getcontext().prec)))
-                )
+                self.n_frac = n_frac = int(np.ceil(math.log2(10**int(getcontext().prec))))
 
             # force return raw value for better precision
-            val = int(val * 2 ** (self.n_frac))
+            val = int(val * 2**(self.n_frac))
             raw = True
 
+
         else:
-            raise ValueError("Not supported input type: {}".format(type(val)))
+            raise ValueError('Not supported input type: {}'.format(type(val)))
 
         # convert to (numpy) ndarray
         val = np.array(val)
 
         if vdtype is None:
             vdtype = val.dtype
-
+        
         # scaling conversion
         self.scaled = False
         if self.scale is not None and self.bias is not None and not raw:
@@ -784,12 +708,12 @@ class Fxp:
                 val = val / self.scale
 
             if self.bias != 0 or self.scale != 1:
-                self.scaled = True  # update scaled flag
+                self.scaled = True # update scaled flag
 
                 # update vdtype due scaling tranformation
                 if vdtype == int and (isinstance(self.bias, float) or self.scale != 1):
                     vdtype = float
-
+            
             # check if it is a numpy array
             if not isinstance(val, (np.ndarray, np.generic)):
                 val = np.array(val)
@@ -805,9 +729,9 @@ class Fxp:
         if raw:
             conv_factor = 1
         elif self.n_frac >= 0:
-            conv_factor = 1 << self.n_frac
+            conv_factor = (1<<self.n_frac)
         else:
-            conv_factor = 1 / (1 << -self.n_frac)
+            conv_factor = 1/(1<<-self.n_frac)
 
         return conv_factor
 
@@ -815,38 +739,24 @@ class Fxp:
         if notation is None:
             notation = self.config.dtype_notation
         else:
-            notation = "fxp"
+            notation = 'fxp'
 
-        if (
-            self.signed is not None
-            and self.n_word is not None
-            and self.n_frac is not None
-        ):
-            if notation == "Q":
-                self._dtype = "{Q}{nint}.{nfrac}".format(
-                    Q="Q" if self.signed else "UQ",
-                    nint=self.n_word - self.n_frac,
-                    nfrac=self.n_frac,
-                )
+        if self.signed is not None and self.n_word is not None and self.n_frac is not None:
+            if notation == 'Q':
+                self._dtype = '{Q}{nint}.{nfrac}'.format(Q='Q' if self.signed else 'UQ',
+                                                        nint=self.n_word-self.n_frac,
+                                                        nfrac=self.n_frac)
             elif self.val is not None:
-                self._dtype = "fxp-{sign}{nword}/{nfrac}{comp}".format(
-                    sign="s" if self.signed else "u",
-                    nword=self.n_word,
-                    nfrac=self.n_frac,
-                    comp=(
-                        "-complex"
-                        if (self.val.dtype == complex or self.vdtype == complex)
-                        else ""
-                    ),
-                )
+                self._dtype = 'fxp-{sign}{nword}/{nfrac}{comp}'.format(sign='s' if self.signed else 'u', 
+                                                                    nword=self.n_word, 
+                                                                    nfrac=self.n_frac, 
+                                                                    comp='-complex' if (self.val.dtype == complex or self.vdtype == complex) else '')
             else:
-                self._dtype = "fxp-{sign}{nword}/{nfrac}".format(
-                    sign="s" if self.signed else "u",
-                    nword=self.n_word,
-                    nfrac=self.n_frac,
-                )
+                self._dtype = 'fxp-{sign}{nword}/{nfrac}'.format(sign='s' if self.signed else 'u', 
+                                                                    nword=self.n_word, 
+                                                                    nfrac=self.n_frac)                
         else:
-            self._dtype = "fxp"
+            self._dtype = 'fxp'
 
     def set_val(self, val, raw=False, vdtype=None, index=None):
         """
@@ -871,7 +781,7 @@ class Fxp:
         ---
 
         self : Fxp object
-            Fxp with it's value modified.
+            Fxp with it's value modified. 
 
         """
 
@@ -880,26 +790,20 @@ class Fxp:
 
         # val limits according word size
         if self.signed:
-            val_max = (1 << (self.n_word - 1)) - 1
+            val_max = (1 << (self.n_word-1)) - 1
             val_min = -val_max - 1
         else:
-            val_max = (1 << self.n_word) - 1
+            val_max =  (1 << self.n_word) - 1
             val_min = 0
 
         # conversion factor
         conv_factor = self._get_conv_factor(raw)
 
         # round, saturate and store
-        if original_vdtype != complex and not np.issubdtype(
-            original_vdtype, np.complexfloating
-        ):
+        if original_vdtype != complex and not np.issubdtype(original_vdtype, np.complexfloating):
             # val_dtype determination
             _n_word_max_ = min(_n_word_max, 64)
-            if (
-                np.max(val) >= 2**_n_word_max_
-                or np.min(val) < -(2**_n_word_max_)
-                or self.n_word >= _n_word_max_
-            ):
+            if np.max(val) >= 2**_n_word_max_ or np.min(val) < -2**_n_word_max_ or self.n_word >= _n_word_max_:
                 val_dtype = object
                 val = val.astype(object)
             else:
@@ -907,20 +811,16 @@ class Fxp:
                 val_dtype = np.int64 if self.signed else np.uint64
 
             # rounding and overflowing
-            new_val = self._round(val * conv_factor, method=self.config.rounding)
+            new_val = self._round(val * conv_factor , method=self.config.rounding)
             new_val = self._overflow_action(new_val, val_min, val_max)
 
             # convert to array of val_dtype
             new_val = new_val.astype(val_dtype)
 
-            if val_dtype == object:
+            if val_dtype == object:       
                 # convert each element to int
-                new_val = (
-                    np.array(list(map(int, new_val.flatten())))
-                    .reshape(new_val.shape)
-                    .astype(val_dtype)
-                )
-
+                new_val = np.array(list(map(int, new_val.flatten()))).reshape(new_val.shape).astype(val_dtype)
+            
             if index is not None:
                 self.val[index] = new_val
             else:
@@ -933,26 +833,18 @@ class Fxp:
             # extract real and imaginary parts
             new_val_real = np.vectorize(lambda v: v.real)(val)
             new_val_imag = np.vectorize(lambda v: v.imag)(val)
-
+            
             # val_dtype determination
             _n_word_max_ = min(_n_word_max, 64)
-            if (
-                np.max(new_val_real) >= 2**_n_word_max_
-                or np.min(new_val_real) < -(2**_n_word_max_)
-                or self.n_word >= _n_word_max_
-            ):
+            if np.max(new_val_real) >= 2**_n_word_max_ or np.min(new_val_real) < -2**_n_word_max_ or self.n_word >= _n_word_max_:
                 val_dtype = object
             else:
                 val = val.astype(original_vdtype)
                 val_dtype = np.int64 if self.signed else np.uint64
-
+            
             # rounding and overflowing
-            new_val_real = self._round(
-                new_val_real * conv_factor, method=self.config.rounding
-            )
-            new_val_imag = self._round(
-                new_val_imag * conv_factor, method=self.config.rounding
-            )
+            new_val_real = self._round(new_val_real * conv_factor, method=self.config.rounding)
+            new_val_imag = self._round(new_val_imag * conv_factor, method=self.config.rounding)
             new_val_real = self._overflow_action(new_val_real, val_min, val_max)
             new_val_imag = self._overflow_action(new_val_imag, val_min, val_max)
 
@@ -960,15 +852,11 @@ class Fxp:
             new_val_real = new_val_real.astype(val_dtype)
             new_val_imag = new_val_imag.astype(val_dtype)
 
-            if val_dtype == object:
+            if val_dtype == object:       
                 # convert each element to int
-                new_val_real = np.array(list(map(int, new_val_real.flatten()))).reshape(
-                    new_val_real.shape
-                )
-                new_val_imag = np.array(list(map(int, new_val_imag.flatten()))).reshape(
-                    new_val_imag.shape
-                )
-
+                new_val_real = np.array(list(map(int, new_val_real.flatten()))).reshape(new_val_real.shape)
+                new_val_imag = np.array(list(map(int, new_val_imag.flatten()))).reshape(new_val_imag.shape)
+            
             # rebuild complex
             new_val = new_val_real + 1j * new_val_imag
 
@@ -993,12 +881,12 @@ class Fxp:
                 self.vdtype = float  # change to float type if Fxp has fractional part
 
         # check inaccuracy
-        if not np.equal(val, new_val / conv_factor).all():
-            self.status["inaccuracy"] = True
-            self._run_callbacks("on_status_inaccuracy")
+        if not np.equal(val, new_val/conv_factor).all() :
+            self.status['inaccuracy'] = True
+            self._run_callbacks('on_status_inaccuracy')
 
         # run changed value callback
-        self._run_callbacks("on_value_change")
+        self._run_callbacks('on_value_change')
 
         return self
 
@@ -1013,7 +901,7 @@ class Fxp:
             Typecode or data-type to which the array is cast.
 
             `None` returns according to `vdtype` of Fxp, if last one is `None`, `float` is returned.
-
+        
         index : int, optional, default=None
             Index of the element to return from list or array of values cast according `dtype`.
 
@@ -1049,18 +937,13 @@ class Fxp:
                 val = raw_val / self._get_conv_factor()
                 if isinstance(val, np.ndarray):
                     val = val.astype(dtype)
-            elif (
-                dtype == int
-                or dtype == "uint"
-                or dtype == "int"
-                or np.issubdtype(dtype, np.integer)
-            ):
+            elif dtype == int or dtype == 'uint' or dtype == 'int' or np.issubdtype(dtype, np.integer):
                 if self.n_frac == 0:
                     val = raw_val
                 else:
                     val = raw_val // self._get_conv_factor()
                     val = np.array(list(map(int, val.flatten()))).reshape(val.shape)
-
+                
             elif dtype == complex or np.issubdtype(dtype, np.complexfloating):
                 val = (raw_val.real + 1j * raw_val.imag) / self._get_conv_factor()
             else:
@@ -1084,7 +967,7 @@ class Fxp:
             Typecode or data-type to which the array is cast.
 
             `None` returns according to `vdtype` of Fxp, if last one is `None`, `float` is returned.
-
+        
         index : int, optional, default=None
             Index of the element to return from list or array of values cast according `dtype`.
 
@@ -1100,7 +983,7 @@ class Fxp:
         ---
         val : number or array
             Value represented in original format (not binary) casted according to `dtype`.
-
+            
         """
 
         if dtype is None:
@@ -1119,7 +1002,7 @@ class Fxp:
         """
 
         return self.val
-
+    
     def uraw(self):
         """
         Returns a tow-complement of fixed-point integer value (unsigned raw value).
@@ -1146,11 +1029,11 @@ class Fxp:
         ---
 
         self : Fxp object
-            Fxp with it's value modified.
+            Fxp with it's value modified. 
         """
-
+        
         if isinstance(x, Fxp):
-            new_val_raw = x.val * 2 ** (self.n_frac - x.n_frac)
+            new_val_raw = x.val * 2**(self.n_frac - x.n_frac)
             self.set_val(new_val_raw, raw=True)
         else:
             self.set_val(x)
@@ -1160,54 +1043,47 @@ class Fxp:
 
     def _overflow_action(self, new_val, val_min, val_max):
         if np.any(new_val > val_max):
-            self.status["overflow"] = True
-            self._run_callbacks("on_status_overflow")
+            self.status['overflow'] = True
+            self._run_callbacks('on_status_overflow')
         if np.any(new_val < val_min):
-            self.status["underflow"] = True
-            self._run_callbacks("on_status_underflow")
-
-        if self.config.overflow == "saturate":
+            self.status['underflow'] = True
+            self._run_callbacks('on_status_underflow')
+        
+        if self.config.overflow == 'saturate':
             if isinstance(new_val, np.ndarray) and new_val.dtype == object:
                 val = np.clip(new_val, val_min, val_max)
             else:
                 val = utils.clip(new_val, val_min, val_max)
 
-        elif self.config.overflow == "wrap":
+        elif self.config.overflow == 'wrap':
             val = utils.wrap(new_val, self.signed, self.n_word)
         else:
-            raise ValueError(
-                "{} is not a valid config for overflow!".format(self.config.overflow)
-            )
+            raise ValueError('{} is not a valid config for overflow!'.format(self.config.overflow))
         return val
 
-    def _round(self, val, method="floor"):
-        if (
-            isinstance(val, int)
-            or np.issubdtype(np.array(val).dtype, np.integer)
-            or np.issubdtype(np.array(val).dtype, np.object_)
-        ):
+    def _round(self, val, method='floor'):
+        if isinstance(val, int) or np.issubdtype(np.array(val).dtype, np.integer) or np.issubdtype(np.array(val).dtype, np.object_):
             rval = val
-        elif method == "around":
+        elif method == 'around':
             rval = np.around(val)
-        elif method == "floor":
+        elif method == 'floor':
             rval = np.floor(val)
-        elif method == "ceil":
+        elif method == 'ceil':
             rval = np.ceil(val)
-        elif method == "fix":
+        elif method == 'fix':
             rval = np.fix(val)
-        elif method == "trunc":
+        elif method == 'trunc':
             rval = np.trunc(val)
-        elif method is None or method == "":
+        elif method is None or method == '':
             rval = val
         else:
-            raise ValueError("<{}> rounding method not valid!")
+            raise ValueError('<{}> rounding method not valid!')
         return rval
 
     def _run_callbacks(self, method):
         if self.callbacks:
             for cb in self.callbacks:
-                if hasattr(cb, method):
-                    getattr(cb, method)(self)
+                if hasattr(cb, method): getattr(cb, method)(self)
 
     # overloadings
 
@@ -1223,119 +1099,90 @@ class Fxp:
 
     def __bool__(self):
         if self.size > 1:
-            raise ValueError(
-                "The boolean value cannot be determined. Use any() or all()."
-            )
+            raise ValueError("The boolean value cannot be determined. Use any() or all().")
         else:
             return bool(self.get_val())
 
     def __int__(self):
         if self.size > 1:
-            raise TypeError("only length-1 arrays can be converted to Python scalars")
+            raise TypeError('only length-1 arrays can be converted to Python scalars')
         return int(self.astype(int))
 
     def __float__(self):
         if self.size > 1:
-            raise TypeError("only length-1 arrays can be converted to Python scalars")
+            raise TypeError('only length-1 arrays can be converted to Python scalars')
         return float(self.astype(float))
 
     def __complex__(self):
         if self.size > 1:
-            raise TypeError("only length-1 arrays can be converted to Python scalars")
+            raise TypeError('only length-1 arrays can be converted to Python scalars')
         return complex(self.astype(complex))
-
+    
     # representation
-
+    
     def __repr__(self):
         dtype_str = self.dtype
-        data_str = str(self.get_val()).replace("\n", "\n " + " " * (len(dtype_str)))
+        data_str = str(self.get_val()).replace('\n', '\n '+' '*(len(dtype_str)))
 
-        return "{}({})".format(self.dtype, data_str)
+        return '{}({})'.format(self.dtype, data_str)
 
     def __str__(self):
         return str(self.get_val())
 
     # numpy array representation - numpy hooks
-
+    
     def __array__(self, *args, **kwargs):
-        if self.config.array_op_method == "raw":
+        if self.config.array_op_method == 'raw':
             return np.asarray(self.val, *args, **kwargs)
         else:
             return np.asarray(self.get_val(), *args, **kwargs)
-
+    
     def __array_wrap__(self, out_arr, context=None):
-        raw = True if self.config.array_op_method == "raw" else False
+        raw = True if self.config.array_op_method == 'raw' else False
 
-        if self.config.array_output_type == "fxp":
+        if self.config.array_output_type == 'fxp':
             if self.config.array_op_out is not None:
                 return self.config.array_op_out.set_val(out_arr, raw=raw)
             elif self.config.array_op_out_like is not None:
-                return self.__class__(
-                    out_arr, like=self.config.array_op_out_like, raw=raw
-                )
+                return self.__class__(out_arr, like=self.config.array_op_out_like, raw=raw)
             else:
                 return self.__class__(out_arr)
         else:
             return out_arr
 
     def __array_prepare__(self, context=None, *args, **kwargs):
-        if self.config.array_op_method == "raw":
+        if self.config.array_op_method == 'raw':
             return np.asarray(self.val, *args, **kwargs)
         else:
             return np.asarray(self.get_val(), *args, **kwargs)
 
     def __array_finalize__(self, obj):
         return
-
+  
     # math operations
-
+    
     def __neg__(self):
-        y = Fxp(
-            -self.val,
-            signed=self.signed,
-            n_word=self.n_word,
-            n_frac=self.n_frac,
-            raw=True,
-        )
+        y = Fxp(-self.val, signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
         return y
 
     def __pos__(self):
-        y = Fxp(
-            +self.val,
-            signed=self.signed,
-            n_word=self.n_word,
-            n_frac=self.n_frac,
-            raw=True,
-        )
+        y = Fxp(+self.val, signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
         return y
 
     def __abs__(self):
-        y = Fxp(
-            abs(self.val),
-            signed=self.signed,
-            n_word=self.n_word,
-            n_frac=self.n_frac,
-            raw=True,
-        )
-        return y
+        y = Fxp(abs(self.val), signed=self.signed, n_word=self.n_word, n_frac=self.n_frac, raw=True)
+        return y          
 
     def __add__(self, x):
         from .functions import add
-
+        
         if not isinstance(x, Fxp):
             x = self._convert_op_input_value(x)
             _sizing = self.config.const_op_sizing
         else:
             _sizing = self.config.op_sizing
 
-        return add(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return add(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __radd__ = __add__
 
@@ -1350,14 +1197,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return sub(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return sub(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     def __rsub__(self, x):
         from .functions import sub
@@ -1369,14 +1209,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return sub(
-            x,
-            self,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return sub(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __isub__ = __sub__
 
@@ -1389,14 +1222,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return mul(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return mul(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __rmul__ = __mul__
 
@@ -1411,14 +1237,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return truediv(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return truediv(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     def __rtruediv__(self, x):
         from .functions import truediv
@@ -1429,14 +1248,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return truediv(
-            x,
-            self,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return truediv(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __itruediv__ = __truediv__
 
@@ -1449,14 +1261,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return floordiv(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return floordiv(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     def __rfloordiv__(self, x):
         from .functions import floordiv
@@ -1467,14 +1272,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return floordiv(
-            x,
-            self,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return floordiv(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __ifloordiv__ = __floordiv__
 
@@ -1487,14 +1285,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return mod(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return mod(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     def __rmod__(self, x):
         from .functions import mod
@@ -1505,14 +1296,7 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return mod(
-            x,
-            self,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return mod(x, self, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __imod__ = __mod__
 
@@ -1525,39 +1309,25 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        return pow(
-            self,
-            x,
-            out=self.config.op_out,
-            out_like=self.config.op_out_like,
-            sizing=_sizing,
-            method=self.config.op_method,
-        )
+        return pow(self, x, out=self.config.op_out, out_like=self.config.op_out_like, sizing=_sizing, method=self.config.op_method)
 
     __rpow__ = __pow__
 
     __ipow__ = __pow__
 
+    
     # bit level operators
 
     def __rshift__(self, n):
-        if self.config.shifting == "expand":
-            min_pow2 = utils.min_pow2(self.val)  # minimum power of 2 in raw val
+        if self.config.shifting == 'expand':
+            min_pow2 = utils.min_pow2(self.val)     # minimum power of 2 in raw val
             if min_pow2 is not None and n > min_pow2:
                 n_frac_expansion = n - min_pow2
             else:
                 n_frac_expansion = 0
-
-            y = Fxp(
-                None,
-                signed=self.signed,
-                n_word=self.n_word + n_frac_expansion,
-                n_frac=self.n_frac + n_frac_expansion,
-            )
-            y.set_val(
-                self.val >> np.array(n - n_frac_expansion, dtype=self.val.dtype),
-                raw=True,
-            )  # set raw val shifted
+            
+            y = Fxp(None, signed=self.signed, n_word=self.n_word+n_frac_expansion, n_frac=self.n_frac+n_frac_expansion)
+            y.set_val(self.val >> np.array(n - n_frac_expansion, dtype=self.val.dtype), raw=True)   # set raw val shifted
         else:
             y = self.deepcopy()
             y.val = y.val >> np.array(n, dtype=y.val.dtype)
@@ -1566,35 +1336,24 @@ class Fxp:
     __irshift__ = __rshift__
 
     def __lshift__(self, n):
-        if self.config.shifting == "expand":
-            n_word = max(
-                self.n_word,
-                int(np.max(np.ceil(np.log2(np.abs(self.val) + 0.5)))) + self.signed + n,
-            )
+        if self.config.shifting == 'expand':
+            n_word = max(self.n_word, int(np.max(np.ceil(np.log2(np.abs(self.val)+0.5)))) + self.signed + n)
         else:
             n_word = self.n_word
 
         y = Fxp(None, signed=self.signed, n_word=n_word, n_frac=self.n_frac)
-
+        
         if self.config.shifting == "keep":
             a = self.val << np.array(n, dtype=self.val.dtype)
             b = np.array((1 << n_word) - 1, dtype=self.val.dtype)
-            # this formatting is necessary for when shifting a 1 in a signed number 
-            # into the MSB. i.e. 1 << 7 == -128, not 127 
-            y.set_val(
-                f"0b{(a & b):0{n_word}b}", 
-                raw=True,
-                vdtype=self.vdtype,
-            )
+            # this formatting is necessary for when shifting a 1 in a signed number
+            # into the MSB. i.e. 1 << 7 == -128, not 127
+            y.set_val(f"0b{(a & b):0{n_word}b}",raw=True, vdtype=self.vdtype)
         else:
-            y.set_val(
-                self.val << np.array(n, dtype=self.val.dtype),
-                raw=True,
-                vdtype=self.vdtype,
-            )  # set raw val shifted
-
+            y.set_val(self.val << np.array(n, dtype=self.val.dtype), raw=True, vdtype=self.vdtype)   # set raw val shifted
+            
         return y
-
+    
     __ilshift__ = __lshift__
 
     def __invert__(self):
@@ -1603,9 +1362,9 @@ class Fxp:
         inverted_val = utils.binary_invert(self.val, n_word=self.n_word)
         if self.signed:
             inverted_val = utils.twos_complement_repr(inverted_val, nbits=self.n_word)
-
+        
         y = self.deepcopy()
-        y.set_val(inverted_val, raw=True, vdtype=self.vdtype)  # set raw val inverted
+        y.set_val(inverted_val, raw=True, vdtype=self.vdtype)   # set raw val inverted
         return y
 
     def __and__(self, x):
@@ -1613,9 +1372,7 @@ class Fxp:
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(
-                    self.val.dtype
-                )  # if it doen't care data type difference
+                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
         else:
             x_val = x
 
@@ -1624,9 +1381,7 @@ class Fxp:
             added_val = utils.twos_complement_repr(added_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(
-            added_val, raw=True, vdtype=self.vdtype
-        )  # set raw val with AND operation
+        y.set_val(added_val, raw=True, vdtype=self.vdtype)   # set raw val with AND operation  
         return y
 
     __rand__ = __and__
@@ -1638,22 +1393,16 @@ class Fxp:
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(
-                    self.val.dtype
-                )  # if it doen't care data type difference
+                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
         else:
             x_val = x
 
-        ored_val = utils.binary_or(
-            self.val.astype(self.val.dtype), x_val, n_word=self.n_word
-        )
+        ored_val = utils.binary_or(self.val.astype(self.val.dtype), x_val, n_word=self.n_word)
         if self.signed:
             ored_val = utils.twos_complement_repr(ored_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(
-            ored_val, raw=True, vdtype=self.vdtype
-        )  # set raw val with OR operation
+        y.set_val(ored_val, raw=True, vdtype=self.vdtype)   # set raw val with OR operation  
         return y
 
     __ror__ = __or__
@@ -1665,27 +1414,22 @@ class Fxp:
             if self.n_word != x.n_word:
                 raise ValueError("Operands dont't have same word size!")
             else:
-                x_val = x.val.astype(
-                    self.val.dtype
-                )  # if it doen't care data type difference
+                x_val = x.val.astype(self.val.dtype) # if it doen't care data type difference
         else:
             x_val = x
 
-        xored_val = utils.binary_xor(
-            self.val.astype(self.val.dtype), x_val, n_word=self.n_word
-        )
+        xored_val = utils.binary_xor(self.val.astype(self.val.dtype), x_val, n_word=self.n_word)
         if self.signed:
             xored_val = utils.twos_complement_repr(xored_val, nbits=self.n_word)
 
         y = self.deepcopy()
-        y.set_val(
-            xored_val, raw=True, vdtype=self.vdtype
-        )  # set raw val with XOR operation
-        return y
+        y.set_val(xored_val, raw=True, vdtype=self.vdtype)   # set raw val with XOR operation  
+        return y  
 
     __rxor__ = __xor__
 
-    __ixor__ = __xor__
+    __ixor__ = __xor__    
+
 
     # comparisons
 
@@ -1735,34 +1479,35 @@ class Fxp:
         if format == dict:
             s = self.status
         elif format == str:
-            s = ""
+            s = ''
             for k, v in self.status.items():
                 if v:
-                    s += "\t{:<8}\t=\t{}\n".format(k, v)
+                    s += '\t{:<8}\t=\t{}\n'.format(k,v)
         return s
 
     def info(self, verbose=1):
-        s = ""
+        s = ''
         if verbose > 0:
-            s += "\tdtype\t\t=\t{}\n".format(self.dtype)
-            s += "\tValue\t\t=\t" + self.__str__() + "\n"
+            s += '\tdtype\t\t=\t{}\n'.format(self.dtype)
+            s += '\tValue\t\t=\t' + self.__str__() + '\n'
             if self.scaled:
-                s += "\tScaling\t\t=\t{} * val + {}\n".format(self.scale, self.bias)
+                s += '\tScaling\t\t=\t{} * val + {}\n'.format(self.scale, self.bias)
             s += self.get_status(format=str)
         if verbose > 1:
-            s += "\n\tSigned\t\t=\t{}\n".format(self.signed)
-            s += "\tWord bits\t=\t{}\n".format(self.n_word)
-            s += "\tFract bits\t=\t{}\n".format(self.n_frac)
-            s += "\tInt bits\t=\t{}\n".format(self.n_int)
-            s += "\tVal data type\t=\t{}\n".format(self.vdtype)
+            s += '\n\tSigned\t\t=\t{}\n'.format(self.signed)
+            s += '\tWord bits\t=\t{}\n'.format(self.n_word)
+            s += '\tFract bits\t=\t{}\n'.format(self.n_frac)
+            s += '\tInt bits\t=\t{}\n'.format(self.n_int)
+            s += '\tVal data type\t=\t{}\n'.format(self.vdtype)
         if verbose > 2:
-            s += "\n\tUpper\t\t=\t{}\n".format(self.upper)
-            s += "\tLower\t\t=\t{}\n".format(self.lower)
-            s += "\tPrecision\t=\t{}\n".format(self.precision)
-            s += "\tOverflow\t=\t{}\n".format(self.config.overflow)
-            s += "\tRounding\t=\t{}\n".format(self.config.rounding)
-            s += "\tShifting\t=\t{}\n".format(self.config.shifting)
+            s += '\n\tUpper\t\t=\t{}\n'.format(self.upper)
+            s += '\tLower\t\t=\t{}\n'.format(self.lower)
+            s += '\tPrecision\t=\t{}\n'.format(self.precision)
+            s += '\tOverflow\t=\t{}\n'.format(self.config.overflow)
+            s += '\tRounding\t=\t{}\n'.format(self.config.rounding)
+            s += '\tShifting\t=\t{}\n'.format(self.config.shifting)
         print(s)
+
 
     # base representations
     def bin(self, frac_dot=False):
@@ -1770,46 +1515,21 @@ class Fxp:
             n_frac_dot = self.n_frac
         else:
             n_frac_dot = None
-
+        
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [
-                    utils.binary_repr(
-                        utils.int_array(val.real), n_word=self.n_word, n_frac=n_frac_dot
-                    )
-                    for val in self.val
-                ]
-                imag_val = [
-                    utils.binary_repr(
-                        utils.int_array(val.imag), n_word=self.n_word, n_frac=n_frac_dot
-                    )
-                    for val in self.val
-                ]
+                real_val = [utils.binary_repr(utils.int_array(val.real), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
+                imag_val = [utils.binary_repr(utils.int_array(val.imag), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [
-                    utils.binary_repr(
-                        utils.int_array(val), n_word=self.n_word, n_frac=n_frac_dot
-                    )
-                    for val in self.val
-                ]
+                rval = [utils.binary_repr(utils.int_array(val), n_word=self.n_word, n_frac=n_frac_dot) for val in self.val]
         else:
             if self.vdtype == complex:
-                real_val = utils.binary_repr(
-                    utils.int_array(self.val.real),
-                    n_word=self.n_word,
-                    n_frac=n_frac_dot,
-                )
-                imag_val = utils.binary_repr(
-                    utils.int_array(self.val.imag),
-                    n_word=self.n_word,
-                    n_frac=n_frac_dot,
-                )
+                real_val = utils.binary_repr(utils.int_array(self.val.real), n_word=self.n_word, n_frac=n_frac_dot)
+                imag_val = utils.binary_repr(utils.int_array(self.val.imag), n_word=self.n_word, n_frac=n_frac_dot)
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = utils.binary_repr(
-                    int(self.val), n_word=self.n_word, n_frac=n_frac_dot
-                )
+                rval = utils.binary_repr(int(self.val), n_word=self.n_word, n_frac=n_frac_dot)
         return rval
 
     def hex(self, padding=True):
@@ -1820,52 +1540,20 @@ class Fxp:
 
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [
-                    utils.hex_repr(
-                        utils.binary_repr(
-                            utils.int_array(val.real), n_word=self.n_word, n_frac=None
-                        ),
-                        n_word=hex_n_word,
-                        base=2,
-                    )
-                    for val in self.val
-                ]
-                imag_val = [
-                    utils.hex_repr(
-                        utils.binary_repr(
-                            utils.int_array(val.imag), n_word=self.n_word, n_frac=None
-                        ),
-                        n_word=hex_n_word,
-                        base=2,
-                    )
-                    for val in self.val
-                ]
+                real_val = [utils.hex_repr(utils.binary_repr(utils.int_array(val.real), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2) for val in self.val]
+                imag_val = [utils.hex_repr(utils.binary_repr(utils.int_array(val.imag), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2) for val in self.val]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [
-                    utils.hex_repr(val, n_word=hex_n_word, base=2) for val in self.bin()
-                ]
+                rval = [utils.hex_repr(val, n_word=hex_n_word, base=2) for val in self.bin()]
         else:
             if self.vdtype == complex:
-                real_val = utils.hex_repr(
-                    utils.binary_repr(
-                        utils.int_array(self.val.real), n_word=self.n_word, n_frac=None
-                    ),
-                    n_word=hex_n_word,
-                    base=2,
-                )
-                imag_val = utils.hex_repr(
-                    utils.binary_repr(
-                        utils.int_array(self.val.imag), n_word=self.n_word, n_frac=None
-                    ),
-                    n_word=hex_n_word,
-                    base=2,
-                )
+                real_val = utils.hex_repr(utils.binary_repr(utils.int_array(self.val.real), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2)
+                imag_val = utils.hex_repr(utils.binary_repr(utils.int_array(self.val.imag), n_word=self.n_word, n_frac=None), n_word=hex_n_word, base=2)
                 rval = utils.complex_repr(real_val, imag_val)
             else:
                 rval = utils.hex_repr(self.bin(), n_word=hex_n_word, base=2)
         return rval
-
+    
     def base_repr(self, base, frac_dot=False):
         if frac_dot:
             n_frac_dot = self.n_frac
@@ -1874,30 +1562,14 @@ class Fxp:
 
         if isinstance(self.val, (list, np.ndarray)) and self.val.ndim > 0:
             if self.vdtype == complex:
-                real_val = [
-                    utils.base_repr(
-                        utils.int_array(val.real), base=base, n_frac=n_frac_dot
-                    )
-                    for val in self.val
-                ]
-                imag_val = [
-                    utils.base_repr(
-                        utils.int_array(val.imag), base=base, n_frac=n_frac_dot
-                    )
-                    for val in self.val
-                ]
+                real_val = [utils.base_repr(utils.int_array(val.real), base=base, n_frac=n_frac_dot)  for val in self.val]
+                imag_val = [utils.base_repr(utils.int_array(val.imag), base=base, n_frac=n_frac_dot)  for val in self.val]
                 rval = utils.complex_repr(real_val, imag_val)
             else:
-                rval = [
-                    utils.base_repr(utils.int_array(val), base=base, n_frac=n_frac_dot)
-                    for val in self.val
-                ]
+                rval = [utils.base_repr(utils.int_array(val), base=base, n_frac=n_frac_dot) for val in self.val]
         else:
             if self.vdtype == complex:
-                rval = utils.complex_repr(
-                    utils.base_repr(int(self.val.real), base=base, n_frac=n_frac_dot),
-                    utils.base_repr(int(self.val.imag), base=base, n_frac=n_frac_dot),
-                )
+                rval = utils.complex_repr(utils.base_repr(int(self.val.real), base=base, n_frac=n_frac_dot), utils.base_repr(int(self.val.imag), base=base, n_frac=n_frac_dot))
             else:
                 rval = utils.base_repr(int(self.val), base=base, n_frac=n_frac_dot)
         return rval
@@ -1911,29 +1583,28 @@ class Fxp:
 
     def like(self, x):
         if isinstance(x, self.__class__):
-            new_raw_val = self.val * 2 ** (x.n_frac - self.n_frac)
-            return x.copy().set_val(new_raw_val, raw=True)
+            new_raw_val = self.val * 2**(x.n_frac - self.n_frac)
+            return  x.copy().set_val(new_raw_val, raw=True)
         else:
-            raise ValueError("`x` should be a Fxp object!")
+            raise ValueError('`x` should be a Fxp object!')
 
     # reset
     def reset(self):
-        # status (overwrite)
-        self.status = {"overflow": False, "underflow": False, "inaccuracy": False}
+        #status (overwrite)
+        self.status = {
+            'overflow': False,
+            'underflow': False,
+            'inaccuracy': False}
 
     def _convert_op_input_value(self, x):
         if not isinstance(x, Fxp):
             if self.config is not None:
-                if self.config.op_input_size == "best":
+                if self.config.op_input_size == 'best':
                     x_fxp = Fxp(x)
-                elif self.config.op_input_size == "same":
+                elif self.config.op_input_size == 'same':
                     x_fxp = Fxp(x, like=self)
                 else:
-                    raise ValueError(
-                        "Sizing parameter not supported: {}".format(
-                            self.config.op_input_size
-                        )
-                    )
+                    raise ValueError('Sizing parameter not supported: {}'.format(self.config.op_input_size))
             else:
                 x_fxp = Fxp(x)
         else:
@@ -1945,21 +1616,19 @@ class Fxp:
 
     # numpy functions dispatch
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        if method == "__call__":
+        if method == '__call__':
             if ufunc in _NUMPY_HANDLED_FUNCTIONS:
                 # dispatch function to implemented in fxpmath
-                return self._set_array_output_type(
-                    _NUMPY_HANDLED_FUNCTIONS[ufunc](*inputs, **kwargs)
-                )
+                return self._set_array_output_type(_NUMPY_HANDLED_FUNCTIONS[ufunc](*inputs, **kwargs))
 
             # call original numpy function and return wrapped result
-            kwargs["method"] = method
+            kwargs['method'] = method
             return self._wrapped_numpy_func(ufunc, *inputs, **kwargs)
         else:
             # return NotImplemented
 
             # call original numpy function and return wrapped result
-            kwargs["method"] = method
+            kwargs['method'] = method
             return self._wrapped_numpy_func(ufunc, *inputs, **kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
@@ -1973,50 +1642,42 @@ class Fxp:
         # __array_function__ to handle Fxp objects
         if not all(issubclass(t, self.__class__) for t in types):
             # return NotImplemented
-            pass  # delegates to implemented functions deal with conversion
+            pass    # delegates to implemented functions deal with conversion
 
         # dispatch function to implemented in fxpmath
-        return self._set_array_output_type(
-            _NUMPY_HANDLED_FUNCTIONS[func](*args, **kwargs)
-        )
+        return self._set_array_output_type(_NUMPY_HANDLED_FUNCTIONS[func](*args, **kwargs))
 
     def _wrapped_numpy_func(self, func, *args, **kwargs):
         # convert func inputs to numpy arrays
-        args = [
-            np.asarray(arg) if isinstance(arg, self.__class__) else arg for arg in args
-        ]
+        args = [np.asarray(arg) if isinstance(arg, self.__class__) else arg for arg in args]
 
         # out parameter extraction if Fxp
         out = None
-        if "out" in kwargs:
-            if isinstance(kwargs["out"], self.__class__):
-                out = kwargs.pop("out", None)
-            elif isinstance(kwargs["out"], tuple) and isinstance(
-                kwargs["out"][0], self.__class__
-            ):
-                out = kwargs.pop("out", None)[0]
+        if 'out' in kwargs:
+            if isinstance(kwargs['out'], self.__class__):
+                out = kwargs.pop('out', None)
+            elif (isinstance(kwargs['out'], tuple) and isinstance(kwargs['out'][0], self.__class__)):
+                out = kwargs.pop('out', None)[0]
             else:
                 out = None
-                kwargs.pop("out")
+                kwargs.pop('out')
 
         # out parameter extraction if Fxp
         out_like = None
-        if "out_like" in kwargs:
-            if isinstance(kwargs["out_like"], self.__class__):
-                out_like = kwargs.pop("out_like", None)
-            elif isinstance(kwargs["out_like"], tuple) and isinstance(
-                kwargs["out_like"][0], self.__class__
-            ):
-                out_like = kwargs.pop("out_like", None)
+        if 'out_like' in kwargs:
+            if isinstance(kwargs['out_like'], self.__class__):
+                out_like = kwargs.pop('out_like', None)
+            elif (isinstance(kwargs['out_like'], tuple) and isinstance(kwargs['out_like'][0], self.__class__)):
+                out_like = kwargs.pop('out_like', None)
             else:
                 out_like = None
-                kwargs.pop("out_like")
+                kwargs.pop('out_like')
 
         # get function if a method is specified
-        if "method" in kwargs and isinstance(kwargs["method"], str):
-            method = kwargs.pop("method")
+        if 'method' in kwargs  and isinstance (kwargs['method'], str):
+            method = kwargs.pop('method')
             func = getattr(func, method)
-
+            
         # calculate (call original numpy function)
         try:
             val = func(*args, **kwargs)
@@ -2045,24 +1706,21 @@ class Fxp:
             return self.__array_wrap__(val)
 
     def _set_array_output_type(self, out_arr):
-        if self.config._array_output_type == "fxp":
-            raw = True if self.config.array_op_method == "raw" else False
+        if self.config._array_output_type == 'fxp':
+            raw = True if self.config.array_op_method == 'raw' else False
 
             if self.config.array_op_out is not None:
                 return self.config.array_op_out.set_val(out_arr, raw=raw)
             elif self.config.array_op_out_like is not None:
-                return self.__class__(
-                    out_arr, like=self.config.array_op_out_like, raw=raw
-                )
+                return self.__class__(out_arr, like=self.config.array_op_out_like, raw=raw)
             elif not isinstance(out_arr, self.__class__):
                 return self.__class__(out_arr)
 
-        elif self.config._array_output_type == "array" and isinstance(
-            out_arr, self.__class__
-        ):
+        elif self.config._array_output_type == 'array' and isinstance(out_arr, self.__class__):
             return np.asarray(out_arr.get_val())
-
+        
         return out_arr
+
 
     # methods derived from Numpy ndarray
 
@@ -2073,155 +1731,97 @@ class Fxp:
         return np.any(np.array(self), axis=axis, **kwargs)
 
     def argmax(self, axis=None, **kwargs):
-        return np.argmax(self.val, axis=axis, **kwargs)  # operates over raw values
+        return np.argmax(self.val, axis=axis, **kwargs)    # operates over raw values
 
     def argmin(self, axis=None, **kwargs):
-        return np.argmin(self.val, axis=axis, **kwargs)  # operates over raw values
+        return np.argmin(self.val, axis=axis, **kwargs)    # operates over raw values
 
     def argpartition(self, axis=-1, **kwargs):
-        return np.argpartition(
-            self.val, axis=axis, **kwargs
-        )  # operates over raw values
+        return np.argpartition(self.val, axis=axis, **kwargs)    # operates over raw values
 
     def argsort(self, axis=-1, **kwargs):
-        return np.argsort(self.val, axis=axis, **kwargs)  # operates over raw values
+        return np.argsort(self.val, axis=axis, **kwargs)    # operates over raw values
 
     def nonzero(self):
         from .functions import nonzero
-
-        return nonzero(self)
+        return nonzero(self)  
 
     def max(self, axis=None, **kwargs):
         from .functions import fxp_max
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return fxp_max(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return fxp_max(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def min(self, axis=None, **kwargs):
         from .functions import fxp_min
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return fxp_min(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return fxp_min(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def mean(self, axis=None, **kwargs):
-        if (
-            not "out" in kwargs
-            and self.config.array_output_type == "fxp"
-            and self.config.array_op_out is None
-            and self.config.array_op_out_like is None
-        ):
-
-            kwargs["out"] = Fxp(
-                like=self
-            )  # define Fxp output with same size by default
+        if not 'out' in kwargs and \
+            self.config.array_output_type == 'fxp' and \
+            self.config.array_op_out is None and self.config.array_op_out_like is None: 
+            
+            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
 
         return np.mean(self, axis=axis, **kwargs)
 
     def std(self, axis=None, **kwargs):
-        if (
-            not "out" in kwargs
-            and self.config.array_output_type == "fxp"
-            and self.config.array_op_out is None
-            and self.config.array_op_out_like is None
-        ):
-
-            kwargs["out"] = Fxp(
-                like=self
-            )  # define Fxp output with same size by default
+        if not 'out' in kwargs and \
+            self.config.array_output_type == 'fxp' and \
+            self.config.array_op_out is None and self.config.array_op_out_like is None: 
+            
+            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
 
         return np.std(self, axis=axis, **kwargs)
 
     def var(self, axis=None, **kwargs):
-        if (
-            not "out" in kwargs
-            and self.config.array_output_type == "fxp"
-            and self.config.array_op_out is None
-            and self.config.array_op_out_like is None
-        ):
-
-            kwargs["out"] = Fxp(
-                like=self
-            )  # define Fxp output with same size by default
+        if not 'out' in kwargs and \
+            self.config.array_output_type == 'fxp' and \
+            self.config.array_op_out is None and self.config.array_op_out_like is None: 
+            
+            kwargs['out'] = Fxp(like=self)  # define Fxp output with same size by default
 
         return np.var(self, axis=axis, **kwargs)
 
     def sum(self, axis=None, **kwargs):
         from .functions import sum
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return sum(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return sum(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def cumsum(self, axis=None, **kwargs):
         from .functions import cumsum
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return cumsum(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return cumsum(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def cumprod(self, axis=None, **kwargs):
         from .functions import cumprod
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return cumprod(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return cumprod(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     ravel = flatten
 
@@ -2234,14 +1834,12 @@ class Fxp:
     def conjugate(self, **kwargs):
         from .functions import conjugate
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return conjugate(
-            self, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs
-        )
+        return conjugate(self, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     conj = conjugate
 
@@ -2249,25 +1847,17 @@ class Fxp:
     def T(self):
         x = self.copy()
         x.val = x.val.T
-        return x
-
+        return x    
+    
     def transpose(self, axes=None, **kwargs):
         from .functions import transpose
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return transpose(
-            self,
-            axes=axes,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return transpose(self, axes=axes, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def item(self, *args):
         if len(args) > 1:
@@ -2282,79 +1872,42 @@ class Fxp:
     def clip(self, a_min=None, a_max=None, **kwargs):
         from .functions import clip
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return clip(
-            self,
-            a_min=a_min,
-            a_max=a_max,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return clip(self, a_min=a_min, a_max=a_max, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)
 
     def diagonal(self, offset=0, axis1=0, axis2=1, **kwargs):
         from .functions import diagonal
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return diagonal(
-            self,
-            offset=offset,
-            axis1=axis1,
-            axis2=axis2,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return diagonal(self, offset=offset, axis1=axis1, axis2=axis2, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs)  
 
     def trace(self, offset=0, axis1=0, axis2=1, **kwargs):
         from .functions import trace
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return trace(
-            self,
-            offset=offset,
-            axis1=axis1,
-            axis2=axis2,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return trace(self, offset=offset, axis1=axis1, axis2=axis2, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
 
     def prod(self, axis=None, **kwargs):
         from .functions import prod
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", self.config.op_sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', self.config.op_sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return prod(
-            self,
-            axis=axis,
-            out=out,
-            out_like=out_like,
-            sizing=sizing,
-            method=method,
-            **kwargs,
-        )
+        return prod(self, axis=axis, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
 
     def dot(self, x, **kwargs):
         from .functions import dot
@@ -2365,54 +1918,50 @@ class Fxp:
         else:
             _sizing = self.config.op_sizing
 
-        out = kwargs.pop("out", self.config.op_out)
-        out_like = kwargs.pop("out_like", self.config.op_out_like)
-        sizing = kwargs.pop("sizing", _sizing)
-        method = kwargs.pop("method", self.config.op_method)
+        out = kwargs.pop('out', self.config.op_out)
+        out_like = kwargs.pop('out_like', self.config.op_out_like)
+        sizing = kwargs.pop('sizing', _sizing)
+        method = kwargs.pop('method', self.config.op_method)
 
-        return dot(
-            self, x, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs
-        )
+        return dot(self, x, out=out, out_like=out_like, sizing=sizing, method=method, **kwargs) 
 
-
-class Config:
+class Config():
     template = None
 
     def __init__(self, **kwargs):
         # size limits
-        self.max_error = kwargs.pop("max_error", 1 / 2**63)
-        self.n_word_max = kwargs.pop("n_word_max", 64)
+        self.max_error = kwargs.pop('max_error', 1 / 2**63)
+        self.n_word_max = kwargs.pop('n_word_max', 64)
 
         # behavior
-        self.overflow = kwargs.pop("overflow", "saturate")
-        self.rounding = kwargs.pop("rounding", "trunc")
-        self.shifting = kwargs.pop("shifting", "expand")
-        self.op_method = kwargs.pop("op_method", "raw")
+        self.overflow = kwargs.pop('overflow', 'saturate')
+        self.rounding = kwargs.pop('rounding', 'trunc')
+        self.shifting = kwargs.pop('shifting', 'expand')
+        self.op_method = kwargs.pop('op_method', 'raw')
 
         # inputs
-        self.op_input_size = kwargs.pop("op_input_size", "same")
+        self.op_input_size = kwargs.pop('op_input_size', 'same')
 
         # alu ops outpus
-        self.op_out = kwargs.pop("op_out", None)
-        self.op_out_like = kwargs.pop("op_out_like", None)
-        self.op_sizing = kwargs.pop("op_sizing", "optimal")
+        self.op_out = kwargs.pop('op_out', None)
+        self.op_out_like = kwargs.pop('op_out_like', None)
+        self.op_sizing = kwargs.pop('op_sizing', 'optimal')
 
         # alu ops with a constant operand
-        self.const_op_sizing = kwargs.pop("const_op_sizing", "same")
+        self.const_op_sizing = kwargs.pop('const_op_sizing', 'same')
 
         # array ops
-        self.array_output_type = kwargs.pop("array_output_type", "fxp")
-        self.array_op_out = kwargs.pop("array_op_out", None)
-        self.array_op_out_like = kwargs.pop("array_op_out_like", None)
-        self.array_op_method = kwargs.pop("array_op_method", "repr")
+        self.array_output_type = kwargs.pop('array_output_type', 'fxp')
+        self.array_op_out = kwargs.pop('array_op_out', None)
+        self.array_op_out_like = kwargs.pop('array_op_out_like', None)
+        self.array_op_method = kwargs.pop('array_op_method', 'repr')
 
         # notation
-        self.dtype_notation = kwargs.pop("dtype_notation", "fxp")
+        self.dtype_notation = kwargs.pop('dtype_notation', 'fxp')
 
         # update from template
         # if `template` is in kwarg, the reference template is updated
-        if "template" in kwargs:
-            self.template = kwargs.pop("template")
+        if 'template' in kwargs: self.template = kwargs.pop('template')
 
         if self.template is not None:
             if isinstance(self.template, Config):
@@ -2427,273 +1976,234 @@ class Config:
     @property
     def max_error(self):
         return self._max_error
-
+    
     @max_error.setter
     def max_error(self, val):
         if val > 0:
             self._max_error = val
         else:
-            raise ValueError("max_error must be greater than 0!")
+            raise ValueError('max_error must be greater than 0!')
 
     # n_word_max
     @property
     def n_word_max(self):
         return self._n_word_max
-
+    
     @n_word_max.setter
     def n_word_max(self, val):
         if isinstance(val, int) and val > 0:
             self._n_word_max = val
         else:
-            raise ValueError("n_word_max must be int type greater than 0!")
+            raise ValueError('n_word_max must be int type greater than 0!')
 
     # overflow
     @property
     def _overflow_list(self):
-        return ["saturate", "wrap"]
+        return ['saturate', 'wrap']
 
     @property
     def overflow(self):
         return self._overflow
-
+    
     @overflow.setter
     def overflow(self, val):
         if isinstance(val, str) and val in self._overflow_list:
             self._overflow = val
         else:
-            raise ValueError(
-                "overflow must be str type with following valid values: {}".format(
-                    self._overflow_list
-                )
-            )
+            raise ValueError('overflow must be str type with following valid values: {}'.format(self._overflow_list))
 
     # rounding
     @property
     def _rounding_list(self):
-        return ["around", "floor", "ceil", "fix", "trunc"]
+        return ['around', 'floor', 'ceil', 'fix', 'trunc']
 
     @property
     def rounding(self):
         return self._rounding
-
+    
     @rounding.setter
     def rounding(self, val):
         if isinstance(val, str) and val in self._rounding_list:
             self._rounding = val
         else:
-            raise ValueError(
-                "rounding must be str type with following valid values: {}".format(
-                    self._rounding_list
-                )
-            )
+            raise ValueError('rounding must be str type with following valid values: {}'.format(self._rounding_list))
 
     # shifting
     @property
     def _shifting_list(self):
-        return ["expand", "trunc", "keep"]
+        return ['expand', 'trunc', 'keep']
 
     @property
     def shifting(self):
         return self._shifting
-
+    
     @shifting.setter
     def shifting(self, val):
         if isinstance(val, str) and val in self._shifting_list:
             self._shifting = val
         else:
-            raise ValueError(
-                "shifting must be str type with following valid values: {}".format(
-                    self._shifting_list
-                )
-            )
+            raise ValueError('shifting must be str type with following valid values: {}'.format(self._shifting_list))
 
     # op_input_size
     @property
     def _op_input_size_list(self):
-        return ["same", "best"]
+        return ['same', 'best']
 
     @property
     def op_input_size(self):
         return self._op_input_size
-
+    
     @op_input_size.setter
     def op_input_size(self, val):
         if isinstance(val, str) and val in self._op_input_size_list:
             self._op_input_size = val
         else:
-            raise ValueError(
-                "op_input_size must be str type with following valid values: {}".format(
-                    self._op_input_size_list
-                )
-            )
+            raise ValueError('op_input_size must be str type with following valid values: {}'.format(self._op_input_size_list))
+    
 
     # op_out
     @property
     def op_out(self):
         return self._op_out
-
+    
     @op_out.setter
     def op_out(self, val):
         if val is None or isinstance(val, Fxp):
             self._op_out = val
         else:
-            raise ValueError("op_out must be a Fxp object or None!")
+            raise ValueError('op_out must be a Fxp object or None!')
 
     # op_out_like
     @property
     def op_out_like(self):
         return self._op_out_like
-
+    
     @op_out_like.setter
     def op_out_like(self, val):
         if val is None or isinstance(val, Fxp):
             self._op_out_like = val
         else:
-            raise ValueError("op_out_like must be a Fxp object or None!")
+            raise ValueError('op_out_like must be a Fxp object or None!')
 
     # op_sizing
     @property
     def _op_sizing_list(self):
-        return ["optimal", "same", "fit", "largest", "smallest"]
+        return ['optimal', 'same', 'fit', 'largest', 'smallest']
 
     @property
     def op_sizing(self):
         return self._op_sizing
-
+    
     @op_sizing.setter
     def op_sizing(self, val):
         if isinstance(val, str) and val in self._op_sizing_list:
             self._op_sizing = val
         else:
-            raise ValueError(
-                "op_sizing must be str type with following valid values: {}".format(
-                    self._op_sizing_list
-                )
-            )
+            raise ValueError('op_sizing must be str type with following valid values: {}'.format(self._op_sizing_list))
 
     # op_method
     @property
     def _op_method_list(self):
-        return ["raw", "repr"]
+        return ['raw', 'repr']
 
     @property
     def op_method(self):
         return self._op_method
-
+    
     @op_method.setter
     def op_method(self, val):
         if isinstance(val, str) and val in self._op_method_list:
             self._op_method = val
         else:
-            raise ValueError(
-                "op_method must be str type with following valid values: {}".format(
-                    self._op_method_list
-                )
-            )
+            raise ValueError('op_method must be str type with following valid values: {}'.format(self._op_method_list))
 
     # const_op_sizing
     @property
     def _const_op_sizing_list(self):
-        return ["optimal", "same", "fit", "largest", "smallest"]
+        return ['optimal', 'same', 'fit', 'largest', 'smallest']
 
     @property
     def const_op_sizing(self):
         return self._const_op_sizing
-
+    
     @const_op_sizing.setter
     def const_op_sizing(self, val):
         if isinstance(val, str) and val in self._const_op_sizing_list:
             self._const_op_sizing = val
         else:
-            raise ValueError(
-                "op_sizing must be str type with following valid values: {}".format(
-                    self._const_op_sizing_list
-                )
-            )
+            raise ValueError('op_sizing must be str type with following valid values: {}'.format(self._const_op_sizing_list))
 
     # array_output_type
     @property
     def _array_output_type_list(self):
-        return ["fxp", "array"]
+        return ['fxp', 'array']
 
     @property
     def array_output_type(self):
         return self._array_output_type
-
+    
     @array_output_type.setter
     def array_output_type(self, val):
         if isinstance(val, str) and val in self._array_output_type_list:
             self._array_output_type = val
         else:
-            raise ValueError(
-                "array_output_type must be str type with following valid values: {}".format(
-                    self._array_output_type_list
-                )
-            )
+            raise ValueError('array_output_type must be str type with following valid values: {}'.format(self._array_output_type_list))
 
     # array_op_out
     @property
     def array_op_out(self):
         return self._array_op_out
-
+    
     @array_op_out.setter
     def array_op_out(self, val):
         if val is None or isinstance(val, Fxp):
             self._array_op_out = val
         else:
-            raise ValueError("array_op_out must be a Fxp object or None!")
+            raise ValueError('array_op_out must be a Fxp object or None!')
 
     # array_op_out_like
     @property
     def array_op_out_like(self):
         return self._array_op_out_like
-
+    
     @array_op_out_like.setter
     def array_op_out_like(self, val):
         if val is None or isinstance(val, Fxp):
             self._array_op_out_like = val
         else:
-            raise ValueError("array_op_out_like must be a Fxp object or None!")
+            raise ValueError('array_op_out_like must be a Fxp object or None!')
 
     # array_op_method
     @property
     def _array_op_method_list(self):
-        return ["raw", "repr"]
+        return ['raw', 'repr']
 
     @property
     def array_op_method(self):
         return self._array_op_method
-
+    
     @array_op_method.setter
     def array_op_method(self, val):
         if isinstance(val, str) and val in self._array_op_method_list:
             self._array_op_method = val
         else:
-            raise ValueError(
-                "array_op_method must be str type with following valid values: {}".format(
-                    self._array_op_method_list
-                )
-            )
+            raise ValueError('array_op_method must be str type with following valid values: {}'.format(self._array_op_method_list))
 
     # dtype_notation
     @property
     def _dtype_notation_list(self):
-        return ["fxp", "Q"]
+        return ['fxp', 'Q']
 
     @property
     def dtype_notation(self):
         return self._dtype_notation
-
+    
     @dtype_notation.setter
     def dtype_notation(self, val):
         if isinstance(val, str) and val in self._dtype_notation_list:
             self._dtype_notation = val
         else:
-            raise ValueError(
-                "dtype_notation must be str type with following valid values: {}".format(
-                    self._dtype_notation_list
-                )
-            )
+            raise ValueError('dtype_notation must be str type with following valid values: {}'.format(self._dtype_notation_list))
 
     # endregion
 
@@ -2704,7 +2214,7 @@ class Config:
 
     def print(self):
         for k, v in self.__dict__.items():
-            print("\t{: <24}:\t{}".format(k.strip("_"), v))
+            print('\t{: <24}:\t{}'.format(k.strip('_'), v))
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -2717,19 +2227,15 @@ class Config:
 
     def deepcopy(self):
         return copy.deepcopy(self)
-
     # endregion
-
 
 # ----------------------------------------------------------------------------------------
 # Internal functions
 # ----------------------------------------------------------------------------------------
 def implements(*np_functions):
-    "Register an __array_function__ implementation for Fxp objects."
-
-    def decorator(fxp_func):
+   "Register an __array_function__ implementation for Fxp objects."
+   def decorator(fxp_func):
         for np_func in np_functions:
             _NUMPY_HANDLED_FUNCTIONS[np_func] = fxp_func
         return fxp_func
-
-    return decorator
+   return decorator

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,6 +1,7 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import fxpmath as fxp
 from fxpmath.objects import Fxp
@@ -8,15 +9,16 @@ from fxpmath import utils
 
 import numpy as np
 
+
 def test_shift_bitwise():
     # integer val
     x = Fxp(32, True, 8, 0)
     # left
     assert (x << 1)() == 64
     assert (x << 2)() == 128
-    assert (x << 2).n_word == 9 
+    assert (x << 2).n_word == 9
     assert (x << 3)() == 256
-    assert (x << 10)() == 32*(2**10)
+    assert (x << 10)() == 32 * (2**10)
     # right
     assert (x >> 1)() == 16
     assert (x >> 2)() == 8
@@ -26,43 +28,43 @@ def test_shift_bitwise():
 
     # float val
     x = Fxp(24.25, True, 8, 2)
-    #left
+    # left
     assert (x << 1)() == 48.5
     assert (x << 4)() == 388.0
-    #right
+    # right
     x = Fxp(24.5, True, 8, 2)
     assert (x >> 1)() == 12.25
     assert (x >> 2)() == 6.125
 
     # negative
     x = Fxp(-24.25, True, 8, 2)
-    #left
+    # left
     assert (x << 1)() == -48.5
     assert (x << 4)() == -388.0
-    #right
+    # right
     x = Fxp(-24.5, True, 8, 2)
     assert (x >> 1)() == -12.25
     assert (x >> 2)() == -6.125
 
     # trunc shift
     # left
-    x = Fxp(32, True, 8, 0, shifting='trunc')
+    x = Fxp(32, True, 8, 0, shifting="trunc")
     assert (x << 1)() == 64
     assert (x << 2)() == x.upper
     # right
     assert (x >> 3)() == 4
     assert (x >> 5)() == 1
-    assert (x >> 6)() == 0    
+    assert (x >> 6)() == 0
 
     # unsigned
 
     x = Fxp(32, False, 8, 0)
     # left
     assert (x << 1)() == 64
-    assert (x << 2)() == 128 
+    assert (x << 2)() == 128
     assert (x << 3)() == 256
     assert (x << 3).n_word == 9
-    assert (x << 10)() == 32*(2**10)
+    assert (x << 10)() == 32 * (2**10)
     # right
     assert (x >> 1)() == 16
     assert (x >> 2)() == 8
@@ -72,51 +74,88 @@ def test_shift_bitwise():
 
     # float val
     x = Fxp(24.25, False, 8, 2)
-    #left
+    # left
     assert (x << 1)() == 48.5
     assert (x << 4)() == 388.0
-    #right
+    # right
     x = Fxp(24.5, False, 8, 2)
     assert (x >> 1)() == 12.25
     assert (x >> 2)() == 6.125
 
     # trunc left shift
-    x = Fxp(64, False, 8, 0, shifting='trunc')
+    x = Fxp(64, False, 8, 0, shifting="trunc")
     assert (x << 1)() == 128
     assert (x << 2)() == x.upper
+
+    # keep shift
+    # left unsigned
+    x = Fxp(1, False, 8, 0, shifting="keep")
+    prev = 1
+    for i in range(x.n_word):
+        assert (x << i)() == prev
+        prev = 2 * prev
+    assert (x << 8)() == 0
+
+    # right unsigned
+    x.set_val(128)
+    prev = 128
+    for i in range(x.n_word):
+        assert (x >> i)() == prev
+        prev = prev // 2
+    assert (x >> 8)() == 0
+
+    # left signed
+    x = Fxp(1, True, 8, 0, shifting="keep")
+    prev = 1
+    for i in range(x.n_word - 1):
+        assert (x << i)() == prev, f"{i}, {prev}"
+        prev = 2 * prev
+    assert (x << x.n_word - 1)() == -128
+    assert (x << x.n_word)() == 0
+    x.set_val(113)
+    for i in range(x.n_word):
+        assert (x << i).bin() == x.bin()[i:] + (i * "0")
+
+    # right signed
+    x.set_val(-128)
+    for i in range(x.n_word):
+        assert (x >> i).bin() == (i + 1) * "1" + (x.n_word - (i + 1)) * "0"
+    assert (x >> 8).bin() == x.n_word * "1"
+
 
 def test_invert():
     x = Fxp(None, True, 8, 4)
     xu = Fxp(None, False, 8, 4)
 
-    x('0b 0010 1100')
+    x("0b 0010 1100")
     y = ~x
-    assert y.bin() == '11010011'
+    assert y.bin() == "11010011"
 
-    x('0b0000 0000')
-    assert (~x).bin() == '11111111'
-    xu('0b0000 0000')
-    assert (~xu).bin() == '11111111'
+    x("0b0000 0000")
+    assert (~x).bin() == "11111111"
+    xu("0b0000 0000")
+    assert (~xu).bin() == "11111111"
 
-    x('0b 1111 1111')
-    assert (~x).bin() == '00000000'
-    xu('0b 1111 1111')
-    assert (~xu).bin() == '00000000'
+    x("0b 1111 1111")
+    assert (~x).bin() == "00000000"
+    xu("0b 1111 1111")
+    assert (~xu).bin() == "00000000"
 
-    x('0b 1000 0000')
-    assert (~x).bin() == '01111111'
-    xu('0b 1000 0000')
-    assert (~xu).bin() == '01111111'
+    x("0b 1000 0000")
+    assert (~x).bin() == "01111111"
+    xu("0b 1000 0000")
+    assert (~xu).bin() == "01111111"
 
     x = Fxp(None, True, 32, 0)
     xu = Fxp(None, False, 32, 0)
 
-    val_str = '10100000111101011100001100110101'
-    inv_str = '01011111000010100011110011001010'
-    x('0b'+val_str)
+    val_str = "10100000111101011100001100110101"
+    inv_str = "01011111000010100011110011001010"
+    x("0b" + val_str)
     assert (~x).bin() == inv_str
-    xu('0b'+val_str)
+    xu("0b" + val_str)
     assert (~xu).bin() == inv_str
+
 
 def test_and():
     x = Fxp(None, True, 8, 4)
@@ -124,41 +163,42 @@ def test_and():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = '00110101'
-    mks_str = '11110000'
-    and_str = '00110000'
+    val_str = "00110101"
+    mks_str = "11110000"
+    and_str = "00110000"
 
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
-
-    assert (x & y).bin() == and_str
-    assert (x & yu).bin() == and_str
-    assert (xu & y).bin() == and_str
-    assert (xu & yu).bin() == and_str
-    assert (x & utils.str2num('0b'+mks_str)).bin() == and_str
-    assert (xu & utils.str2num('0b'+mks_str)).bin() == and_str
-    assert (utils.str2num('0b'+mks_str) & x).bin() == and_str
-    assert (utils.str2num('0b'+mks_str) & xu).bin() == and_str
-
-    val_str = '10101100'
-    mks_str = '11001100'
-    and_str = '10001100'
-
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
 
     assert (x & y).bin() == and_str
     assert (x & yu).bin() == and_str
     assert (xu & y).bin() == and_str
     assert (xu & yu).bin() == and_str
-    assert (x & utils.str2num('0b'+mks_str)).bin() == and_str
-    assert (xu & utils.str2num('0b'+mks_str)).bin() == and_str
-    assert (utils.str2num('0b'+mks_str) & x).bin() == and_str
-    assert (utils.str2num('0b'+mks_str) & xu).bin() == and_str
+    assert (x & utils.str2num("0b" + mks_str)).bin() == and_str
+    assert (xu & utils.str2num("0b" + mks_str)).bin() == and_str
+    assert (utils.str2num("0b" + mks_str) & x).bin() == and_str
+    assert (utils.str2num("0b" + mks_str) & xu).bin() == and_str
+
+    val_str = "10101100"
+    mks_str = "11001100"
+    and_str = "10001100"
+
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
+
+    assert (x & y).bin() == and_str
+    assert (x & yu).bin() == and_str
+    assert (xu & y).bin() == and_str
+    assert (xu & yu).bin() == and_str
+    assert (x & utils.str2num("0b" + mks_str)).bin() == and_str
+    assert (xu & utils.str2num("0b" + mks_str)).bin() == and_str
+    assert (utils.str2num("0b" + mks_str) & x).bin() == and_str
+    assert (utils.str2num("0b" + mks_str) & xu).bin() == and_str
+
 
 def test_or():
     x = Fxp(None, True, 8, 4)
@@ -166,41 +206,42 @@ def test_or():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = '00110101'
-    mks_str = '11110000'
-    or_str  = '11110101'
+    val_str = "00110101"
+    mks_str = "11110000"
+    or_str = "11110101"
 
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
-
-    assert (x | y).bin() == or_str
-    assert (x | yu).bin() == or_str
-    assert (xu | y).bin() == or_str
-    assert (xu | yu).bin() == or_str
-    assert (x | utils.str2num('0b'+mks_str)).bin() == or_str
-    assert (xu | utils.str2num('0b'+mks_str)).bin() == or_str
-    assert (utils.str2num('0b'+mks_str) | x).bin() == or_str
-    assert (utils.str2num('0b'+mks_str) | xu).bin() == or_str
-
-    val_str = '10101100'
-    mks_str = '11001100'
-    or_str  = '11101100'
-
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
 
     assert (x | y).bin() == or_str
     assert (x | yu).bin() == or_str
     assert (xu | y).bin() == or_str
     assert (xu | yu).bin() == or_str
-    assert (x | utils.str2num('0b'+mks_str)).bin() == or_str
-    assert (xu | utils.str2num('0b'+mks_str)).bin() == or_str
-    assert (utils.str2num('0b'+mks_str) | x).bin() == or_str
-    assert (utils.str2num('0b'+mks_str) | xu).bin() == or_str
+    assert (x | utils.str2num("0b" + mks_str)).bin() == or_str
+    assert (xu | utils.str2num("0b" + mks_str)).bin() == or_str
+    assert (utils.str2num("0b" + mks_str) | x).bin() == or_str
+    assert (utils.str2num("0b" + mks_str) | xu).bin() == or_str
+
+    val_str = "10101100"
+    mks_str = "11001100"
+    or_str = "11101100"
+
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
+
+    assert (x | y).bin() == or_str
+    assert (x | yu).bin() == or_str
+    assert (xu | y).bin() == or_str
+    assert (xu | yu).bin() == or_str
+    assert (x | utils.str2num("0b" + mks_str)).bin() == or_str
+    assert (xu | utils.str2num("0b" + mks_str)).bin() == or_str
+    assert (utils.str2num("0b" + mks_str) | x).bin() == or_str
+    assert (utils.str2num("0b" + mks_str) | xu).bin() == or_str
+
 
 def test_xor():
     x = Fxp(None, True, 8, 4)
@@ -208,56 +249,78 @@ def test_xor():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = '00110101'
-    mks_str = '11110000'
-    xor_str = '11000101'
+    val_str = "00110101"
+    mks_str = "11110000"
+    xor_str = "11000101"
 
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
-
-    assert (x ^ y).bin() == xor_str
-    assert (x ^ yu).bin() == xor_str
-    assert (xu ^ y).bin() == xor_str
-    assert (xu ^ yu).bin() == xor_str
-    assert (x ^ utils.str2num('0b'+mks_str)).bin() == xor_str
-    assert (xu ^ utils.str2num('0b'+mks_str)).bin() == xor_str
-    assert (utils.str2num('0b'+mks_str) ^ x).bin() == xor_str
-    assert (utils.str2num('0b'+mks_str) ^ xu).bin() == xor_str
-
-    val_str = '10101100'
-    mks_str = '11001100'
-    xor_str = '01100000'
-
-    x('0b'+val_str)
-    xu('0b'+val_str)
-    y('0b'+mks_str)
-    yu('0b'+mks_str)
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
 
     assert (x ^ y).bin() == xor_str
     assert (x ^ yu).bin() == xor_str
     assert (xu ^ y).bin() == xor_str
     assert (xu ^ yu).bin() == xor_str
-    assert (x ^ utils.str2num('0b'+mks_str)).bin() == xor_str
-    assert (xu ^ utils.str2num('0b'+mks_str)).bin() == xor_str
-    assert (utils.str2num('0b'+mks_str) ^ x).bin() == xor_str
-    assert (utils.str2num('0b'+mks_str) ^ xu).bin() == xor_str
+    assert (x ^ utils.str2num("0b" + mks_str)).bin() == xor_str
+    assert (xu ^ utils.str2num("0b" + mks_str)).bin() == xor_str
+    assert (utils.str2num("0b" + mks_str) ^ x).bin() == xor_str
+    assert (utils.str2num("0b" + mks_str) ^ xu).bin() == xor_str
+
+    val_str = "10101100"
+    mks_str = "11001100"
+    xor_str = "01100000"
+
+    x("0b" + val_str)
+    xu("0b" + val_str)
+    y("0b" + mks_str)
+    yu("0b" + mks_str)
+
+    assert (x ^ y).bin() == xor_str
+    assert (x ^ yu).bin() == xor_str
+    assert (xu ^ y).bin() == xor_str
+    assert (xu ^ yu).bin() == xor_str
+    assert (x ^ utils.str2num("0b" + mks_str)).bin() == xor_str
+    assert (xu ^ utils.str2num("0b" + mks_str)).bin() == xor_str
+    assert (utils.str2num("0b" + mks_str) ^ x).bin() == xor_str
+    assert (utils.str2num("0b" + mks_str) ^ xu).bin() == xor_str
+
 
 def test_arrays():
     x = Fxp(None, True, 8, 4)
     y = Fxp(None, True, 8, 4)
 
-    x(['0b00110101', '0b10101100'])
-    y('0b11110000')
+    x(["0b00110101", "0b10101100"])
+    y("0b11110000")
 
     z = x & y
-    assert z.bin()[0] == '00110000'
-    assert z.bin()[1] == '10100000'
+    assert z.bin()[0] == "00110000"
+    assert z.bin()[1] == "10100000"
+
 
 def test_operations_with_combinations():
-    
-    v = [-256, -64, -16, -4.75, -3.75, -3.25, -1, -0.75, -0.125, 0.0, 0.125, 0.75, 1, 1.5, 3.75, 4.0, 8.0, 32, 128]
+
+    v = [
+        -256,
+        -64,
+        -16,
+        -4.75,
+        -3.75,
+        -3.25,
+        -1,
+        -0.75,
+        -0.125,
+        0.0,
+        0.125,
+        0.75,
+        1,
+        1.5,
+        3.75,
+        4.0,
+        8.0,
+        32,
+        128,
+    ]
     for i in range(len(v)):
         for j in range(len(v)):
             vx, vy = v[i], v[j]
@@ -272,7 +335,25 @@ def test_operations_with_combinations():
             assert (vx * vy) == (x * y)()
             assert (vy * vx) == (y * x)()
 
-    v = [-256, -64, -16, -4.75, -4.25, -1, -0.75, -0.125, 0.125, 0.75, 1, 1.5, 2.75, 4.0, 8.0, 32, 128]
+    v = [
+        -256,
+        -64,
+        -16,
+        -4.75,
+        -4.25,
+        -1,
+        -0.75,
+        -0.125,
+        0.125,
+        0.75,
+        1,
+        1.5,
+        2.75,
+        4.0,
+        8.0,
+        32,
+        128,
+    ]
     d = [-256, -64, -16, -1, -0.5, -0.125, 0.125, 0.5, 1, 2, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(d)):
@@ -286,9 +367,30 @@ def test_operations_with_combinations():
 
             assert (vx % vy) == (x % y)()
 
+
 def test_operations_with_constants_with_combinations():
-    
-    v = [-256, -64, -16, -4.75, -3.75, -3.25, -1, -0.75, -0.125, 0.0, 0.125, 0.75, 1, 1.5, 3.75, 4.0, 8.0, 32, 128]
+
+    v = [
+        -256,
+        -64,
+        -16,
+        -4.75,
+        -3.75,
+        -3.25,
+        -1,
+        -0.75,
+        -0.125,
+        0.0,
+        0.125,
+        0.75,
+        1,
+        1.5,
+        3.75,
+        4.0,
+        8.0,
+        32,
+        128,
+    ]
     for i in range(len(v)):
         for j in range(len(v)):
             vx, vy = v[i], v[j]
@@ -309,7 +411,25 @@ def test_operations_with_constants_with_combinations():
             assert (x * vy)() == (vx * vy) == (vx * y)() == (x * y)()
             assert (vy * x)() == (vy * vx) == (y * vx)() == (y * x)()
 
-    v = [-256, -64, -16, -4.75, -4.25, -1, -0.75, -0.125, 0.125, 0.75, 1, 1.5, 2.75, 4.0, 8.0, 32, 128]
+    v = [
+        -256,
+        -64,
+        -16,
+        -4.75,
+        -4.25,
+        -1,
+        -0.75,
+        -0.125,
+        0.125,
+        0.75,
+        1,
+        1.5,
+        2.75,
+        4.0,
+        8.0,
+        32,
+        128,
+    ]
     d = [-256, -64, -16, -1, -0.5, -0.125, 0.125, 0.5, 1, 2, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(d)):
@@ -326,10 +446,11 @@ def test_operations_with_constants_with_combinations():
             assert (x % vy)() == (vx % vy) == (vx % y)() == (x % y)()
             # assert (vy % x)() == (vy % vx) == (y % vx)() == (y % x)()
 
+
 def test_pow():
     x = Fxp(16, True, n_int=14, n_frac=8)
     n = Fxp(-1, True, n_int=14, n_frac=8)
-    assert(x**n)() == 1/16
+    assert (x**n)() == 1 / 16
 
     v = 15
     n_vals = [0, 1, 2, 3]
@@ -339,7 +460,7 @@ def test_pow():
     for n in n_vals:
         assert (x**n)() == v**n
         assert (xu**n)() == v**n
-    
+
     v = -16
     x = Fxp(v, signed=True, n_int=12, n_frac=0)
     for n in n_vals:
@@ -353,11 +474,11 @@ def test_pow():
     for n in n_vals:
         assert (x**n)() == v**n
         # assert (xu**n)() == v**n
-    
+
     v = -16.0
     x = Fxp(v, signed=True, n_int=14, n_frac=8)
     for n in n_vals:
-        assert (x**n)() == (v)**n
+        assert (x**n)() == (v) ** n
 
     v = 81
     n_vals = [0, 0.25, 0.5]
@@ -368,8 +489,7 @@ def test_pow():
         assert (x**n)() == v**n
         assert (xu**n)() == v**n
 
-
-    v = 16.
+    v = 16.0
     n = 2
     v_vals = [-4, -2, -1, 0, 1, 2, 4]
     n_vals = [-2, -1, 0, 1, 2]
@@ -383,14 +503,14 @@ def test_pow():
 
     x = Fxp(v, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x.config.op_sizing = 'same'
+    x.config.op_sizing = "same"
     assert ((x**p_vals)() == np.power(v, n_vals)).all()
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
     assert ((x**p_vals)() == np.power(v, n_vals)).all()
 
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p = Fxp(n, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = 'same'
+    x_vals.config.op_sizing = "same"
     assert ((x_vals**p)() == np.power(v_vals, n)).all()
     p = Fxp(n, signed=True, n_int=8, n_frac=2)
     assert ((x_vals**p)() == np.power(v_vals, n)).all()
@@ -399,27 +519,33 @@ def test_pow():
     n_vals = [-2, -1, 0, 1, 2]
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = 'same'
-    assert ((x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])).all()
+    x_vals.config.op_sizing = "same"
+    assert (
+        (x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])
+    ).all()
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=2)
-    assert ((x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])).all()
+    assert (
+        (x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])
+    ).all()
 
-    v_vals = [[1, 2],[3, 4]]
-    n_vals = [[1, 2],[3, 4]]
+    v_vals = [[1, 2], [3, 4]]
+    n_vals = [[1, 2], [3, 4]]
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = 'same'
+    x_vals.config.op_sizing = "same"
     assert ((x_vals**p_vals)() == np.power(v_vals, n_vals)).all()
+
 
 def test_scaled():
     x = Fxp(10.5, True, 16, 8, scale=2, bias=1)
 
     assert x() == 10.5
-    
+
     assert x + 2 == 12.5
     assert x - 2.5 == 8.0
     assert x * 3 == 31.5
     assert x / 2 == 5.25
+
 
 def test_abs():
     x = Fxp(-3.5, True, 32, 16)
@@ -429,4 +555,3 @@ def test_abs():
 
     x = Fxp(3.5, True, 32, 16)
     assert abs(x)() == 3.5
-    

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -26,20 +26,20 @@ def test_shift_bitwise():
 
     # float val
     x = Fxp(24.25, True, 8, 2)
-    # left
+    #left
     assert (x << 1)() == 48.5
     assert (x << 4)() == 388.0
-    # right
+    #right
     x = Fxp(24.5, True, 8, 2)
     assert (x >> 1)() == 12.25
     assert (x >> 2)() == 6.125
 
     # negative
     x = Fxp(-24.25, True, 8, 2)
-    # left
+    #left
     assert (x << 1)() == -48.5
     assert (x << 4)() == -388.0
-    # right
+    #right
     x = Fxp(-24.5, True, 8, 2)
     assert (x >> 1)() == -12.25
     assert (x >> 2)() == -6.125
@@ -72,10 +72,10 @@ def test_shift_bitwise():
 
     # float val
     x = Fxp(24.25, False, 8, 2)
-    # left
+    #left
     assert (x << 1)() == 48.5
     assert (x << 4)() == 388.0
-    # right
+    #right
     x = Fxp(24.5, False, 8, 2)
     assert (x >> 1)() == 12.25
     assert (x >> 2)() == 6.125
@@ -84,16 +84,7 @@ def test_shift_bitwise():
     x = Fxp(64, False, 8, 0, shifting='trunc')
     assert (x << 1)() == 128
     assert (x << 2)() == x.upper
-
-    # keep shift
-    # left unsigned
-    x = Fxp(1, False, 8, 0, shifting="keep")
-    prev = 1
-    for i in range(x.n_word):
-        assert (x << i)() == prev
-        prev = 2 * prev
-    assert (x << 8)() == 0
-
+    
     # right unsigned
     x.set_val(128)
     prev = 128
@@ -464,3 +455,4 @@ def test_abs():
 
     x = Fxp(3.5, True, 32, 16)
     assert abs(x)() == 3.5
+    

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -85,6 +85,15 @@ def test_shift_bitwise():
     assert (x << 1)() == 128
     assert (x << 2)() == x.upper
     
+    # keep shift
+    # left unsigned
+    x = Fxp(1, False, 8, 0, shifting="keep")
+    prev = 1
+    for i in range(x.n_word):
+        assert (x << i)() == prev
+        prev = 2 * prev
+    assert (x << 8)() == 0
+
     # right unsigned
     x.set_val(128)
     prev = 128

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,6 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import fxpmath as fxp
 from fxpmath.objects import Fxp
@@ -9,16 +8,15 @@ from fxpmath import utils
 
 import numpy as np
 
-
 def test_shift_bitwise():
     # integer val
     x = Fxp(32, True, 8, 0)
     # left
     assert (x << 1)() == 64
     assert (x << 2)() == 128
-    assert (x << 2).n_word == 9
+    assert (x << 2).n_word == 9 
     assert (x << 3)() == 256
-    assert (x << 10)() == 32 * (2**10)
+    assert (x << 10)() == 32*(2**10)
     # right
     assert (x >> 1)() == 16
     assert (x >> 2)() == 8
@@ -48,23 +46,23 @@ def test_shift_bitwise():
 
     # trunc shift
     # left
-    x = Fxp(32, True, 8, 0, shifting="trunc")
+    x = Fxp(32, True, 8, 0, shifting='trunc')
     assert (x << 1)() == 64
     assert (x << 2)() == x.upper
     # right
     assert (x >> 3)() == 4
     assert (x >> 5)() == 1
-    assert (x >> 6)() == 0
+    assert (x >> 6)() == 0    
 
     # unsigned
 
     x = Fxp(32, False, 8, 0)
     # left
     assert (x << 1)() == 64
-    assert (x << 2)() == 128
+    assert (x << 2)() == 128 
     assert (x << 3)() == 256
     assert (x << 3).n_word == 9
-    assert (x << 10)() == 32 * (2**10)
+    assert (x << 10)() == 32*(2**10)
     # right
     assert (x >> 1)() == 16
     assert (x >> 2)() == 8
@@ -83,7 +81,7 @@ def test_shift_bitwise():
     assert (x >> 2)() == 6.125
 
     # trunc left shift
-    x = Fxp(64, False, 8, 0, shifting="trunc")
+    x = Fxp(64, False, 8, 0, shifting='trunc')
     assert (x << 1)() == 128
     assert (x << 2)() == x.upper
 
@@ -122,40 +120,38 @@ def test_shift_bitwise():
         assert (x >> i).bin() == (i + 1) * "1" + (x.n_word - (i + 1)) * "0"
     assert (x >> 8).bin() == x.n_word * "1"
 
-
 def test_invert():
     x = Fxp(None, True, 8, 4)
     xu = Fxp(None, False, 8, 4)
 
-    x("0b 0010 1100")
+    x('0b 0010 1100')
     y = ~x
-    assert y.bin() == "11010011"
+    assert y.bin() == '11010011'
 
-    x("0b0000 0000")
-    assert (~x).bin() == "11111111"
-    xu("0b0000 0000")
-    assert (~xu).bin() == "11111111"
+    x('0b0000 0000')
+    assert (~x).bin() == '11111111'
+    xu('0b0000 0000')
+    assert (~xu).bin() == '11111111'
 
-    x("0b 1111 1111")
-    assert (~x).bin() == "00000000"
-    xu("0b 1111 1111")
-    assert (~xu).bin() == "00000000"
+    x('0b 1111 1111')
+    assert (~x).bin() == '00000000'
+    xu('0b 1111 1111')
+    assert (~xu).bin() == '00000000'
 
-    x("0b 1000 0000")
-    assert (~x).bin() == "01111111"
-    xu("0b 1000 0000")
-    assert (~xu).bin() == "01111111"
+    x('0b 1000 0000')
+    assert (~x).bin() == '01111111'
+    xu('0b 1000 0000')
+    assert (~xu).bin() == '01111111'
 
     x = Fxp(None, True, 32, 0)
     xu = Fxp(None, False, 32, 0)
 
-    val_str = "10100000111101011100001100110101"
-    inv_str = "01011111000010100011110011001010"
-    x("0b" + val_str)
+    val_str = '10100000111101011100001100110101'
+    inv_str = '01011111000010100011110011001010'
+    x('0b'+val_str)
     assert (~x).bin() == inv_str
-    xu("0b" + val_str)
+    xu('0b'+val_str)
     assert (~xu).bin() == inv_str
-
 
 def test_and():
     x = Fxp(None, True, 8, 4)
@@ -163,42 +159,41 @@ def test_and():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = "00110101"
-    mks_str = "11110000"
-    and_str = "00110000"
+    val_str = '00110101'
+    mks_str = '11110000'
+    and_str = '00110000'
 
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
-
-    assert (x & y).bin() == and_str
-    assert (x & yu).bin() == and_str
-    assert (xu & y).bin() == and_str
-    assert (xu & yu).bin() == and_str
-    assert (x & utils.str2num("0b" + mks_str)).bin() == and_str
-    assert (xu & utils.str2num("0b" + mks_str)).bin() == and_str
-    assert (utils.str2num("0b" + mks_str) & x).bin() == and_str
-    assert (utils.str2num("0b" + mks_str) & xu).bin() == and_str
-
-    val_str = "10101100"
-    mks_str = "11001100"
-    and_str = "10001100"
-
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
 
     assert (x & y).bin() == and_str
     assert (x & yu).bin() == and_str
     assert (xu & y).bin() == and_str
     assert (xu & yu).bin() == and_str
-    assert (x & utils.str2num("0b" + mks_str)).bin() == and_str
-    assert (xu & utils.str2num("0b" + mks_str)).bin() == and_str
-    assert (utils.str2num("0b" + mks_str) & x).bin() == and_str
-    assert (utils.str2num("0b" + mks_str) & xu).bin() == and_str
+    assert (x & utils.str2num('0b'+mks_str)).bin() == and_str
+    assert (xu & utils.str2num('0b'+mks_str)).bin() == and_str
+    assert (utils.str2num('0b'+mks_str) & x).bin() == and_str
+    assert (utils.str2num('0b'+mks_str) & xu).bin() == and_str
 
+    val_str = '10101100'
+    mks_str = '11001100'
+    and_str = '10001100'
+
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
+
+    assert (x & y).bin() == and_str
+    assert (x & yu).bin() == and_str
+    assert (xu & y).bin() == and_str
+    assert (xu & yu).bin() == and_str
+    assert (x & utils.str2num('0b'+mks_str)).bin() == and_str
+    assert (xu & utils.str2num('0b'+mks_str)).bin() == and_str
+    assert (utils.str2num('0b'+mks_str) & x).bin() == and_str
+    assert (utils.str2num('0b'+mks_str) & xu).bin() == and_str
 
 def test_or():
     x = Fxp(None, True, 8, 4)
@@ -206,42 +201,41 @@ def test_or():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = "00110101"
-    mks_str = "11110000"
-    or_str = "11110101"
+    val_str = '00110101'
+    mks_str = '11110000'
+    or_str  = '11110101'
 
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
-
-    assert (x | y).bin() == or_str
-    assert (x | yu).bin() == or_str
-    assert (xu | y).bin() == or_str
-    assert (xu | yu).bin() == or_str
-    assert (x | utils.str2num("0b" + mks_str)).bin() == or_str
-    assert (xu | utils.str2num("0b" + mks_str)).bin() == or_str
-    assert (utils.str2num("0b" + mks_str) | x).bin() == or_str
-    assert (utils.str2num("0b" + mks_str) | xu).bin() == or_str
-
-    val_str = "10101100"
-    mks_str = "11001100"
-    or_str = "11101100"
-
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
 
     assert (x | y).bin() == or_str
     assert (x | yu).bin() == or_str
     assert (xu | y).bin() == or_str
     assert (xu | yu).bin() == or_str
-    assert (x | utils.str2num("0b" + mks_str)).bin() == or_str
-    assert (xu | utils.str2num("0b" + mks_str)).bin() == or_str
-    assert (utils.str2num("0b" + mks_str) | x).bin() == or_str
-    assert (utils.str2num("0b" + mks_str) | xu).bin() == or_str
+    assert (x | utils.str2num('0b'+mks_str)).bin() == or_str
+    assert (xu | utils.str2num('0b'+mks_str)).bin() == or_str
+    assert (utils.str2num('0b'+mks_str) | x).bin() == or_str
+    assert (utils.str2num('0b'+mks_str) | xu).bin() == or_str
 
+    val_str = '10101100'
+    mks_str = '11001100'
+    or_str  = '11101100'
+
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
+
+    assert (x | y).bin() == or_str
+    assert (x | yu).bin() == or_str
+    assert (xu | y).bin() == or_str
+    assert (xu | yu).bin() == or_str
+    assert (x | utils.str2num('0b'+mks_str)).bin() == or_str
+    assert (xu | utils.str2num('0b'+mks_str)).bin() == or_str
+    assert (utils.str2num('0b'+mks_str) | x).bin() == or_str
+    assert (utils.str2num('0b'+mks_str) | xu).bin() == or_str
 
 def test_xor():
     x = Fxp(None, True, 8, 4)
@@ -249,78 +243,56 @@ def test_xor():
     y = Fxp(None, True, 8, 4)
     yu = Fxp(None, False, 8, 4)
 
-    val_str = "00110101"
-    mks_str = "11110000"
-    xor_str = "11000101"
+    val_str = '00110101'
+    mks_str = '11110000'
+    xor_str = '11000101'
 
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
-
-    assert (x ^ y).bin() == xor_str
-    assert (x ^ yu).bin() == xor_str
-    assert (xu ^ y).bin() == xor_str
-    assert (xu ^ yu).bin() == xor_str
-    assert (x ^ utils.str2num("0b" + mks_str)).bin() == xor_str
-    assert (xu ^ utils.str2num("0b" + mks_str)).bin() == xor_str
-    assert (utils.str2num("0b" + mks_str) ^ x).bin() == xor_str
-    assert (utils.str2num("0b" + mks_str) ^ xu).bin() == xor_str
-
-    val_str = "10101100"
-    mks_str = "11001100"
-    xor_str = "01100000"
-
-    x("0b" + val_str)
-    xu("0b" + val_str)
-    y("0b" + mks_str)
-    yu("0b" + mks_str)
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
 
     assert (x ^ y).bin() == xor_str
     assert (x ^ yu).bin() == xor_str
     assert (xu ^ y).bin() == xor_str
     assert (xu ^ yu).bin() == xor_str
-    assert (x ^ utils.str2num("0b" + mks_str)).bin() == xor_str
-    assert (xu ^ utils.str2num("0b" + mks_str)).bin() == xor_str
-    assert (utils.str2num("0b" + mks_str) ^ x).bin() == xor_str
-    assert (utils.str2num("0b" + mks_str) ^ xu).bin() == xor_str
+    assert (x ^ utils.str2num('0b'+mks_str)).bin() == xor_str
+    assert (xu ^ utils.str2num('0b'+mks_str)).bin() == xor_str
+    assert (utils.str2num('0b'+mks_str) ^ x).bin() == xor_str
+    assert (utils.str2num('0b'+mks_str) ^ xu).bin() == xor_str
 
+    val_str = '10101100'
+    mks_str = '11001100'
+    xor_str = '01100000'
+
+    x('0b'+val_str)
+    xu('0b'+val_str)
+    y('0b'+mks_str)
+    yu('0b'+mks_str)
+
+    assert (x ^ y).bin() == xor_str
+    assert (x ^ yu).bin() == xor_str
+    assert (xu ^ y).bin() == xor_str
+    assert (xu ^ yu).bin() == xor_str
+    assert (x ^ utils.str2num('0b'+mks_str)).bin() == xor_str
+    assert (xu ^ utils.str2num('0b'+mks_str)).bin() == xor_str
+    assert (utils.str2num('0b'+mks_str) ^ x).bin() == xor_str
+    assert (utils.str2num('0b'+mks_str) ^ xu).bin() == xor_str
 
 def test_arrays():
     x = Fxp(None, True, 8, 4)
     y = Fxp(None, True, 8, 4)
 
-    x(["0b00110101", "0b10101100"])
-    y("0b11110000")
+    x(['0b00110101', '0b10101100'])
+    y('0b11110000')
 
     z = x & y
-    assert z.bin()[0] == "00110000"
-    assert z.bin()[1] == "10100000"
-
+    assert z.bin()[0] == '00110000'
+    assert z.bin()[1] == '10100000'
 
 def test_operations_with_combinations():
-
-    v = [
-        -256,
-        -64,
-        -16,
-        -4.75,
-        -3.75,
-        -3.25,
-        -1,
-        -0.75,
-        -0.125,
-        0.0,
-        0.125,
-        0.75,
-        1,
-        1.5,
-        3.75,
-        4.0,
-        8.0,
-        32,
-        128,
-    ]
+    
+    v = [-256, -64, -16, -4.75, -3.75, -3.25, -1, -0.75, -0.125, 0.0, 0.125, 0.75, 1, 1.5, 3.75, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(v)):
             vx, vy = v[i], v[j]
@@ -335,25 +307,7 @@ def test_operations_with_combinations():
             assert (vx * vy) == (x * y)()
             assert (vy * vx) == (y * x)()
 
-    v = [
-        -256,
-        -64,
-        -16,
-        -4.75,
-        -4.25,
-        -1,
-        -0.75,
-        -0.125,
-        0.125,
-        0.75,
-        1,
-        1.5,
-        2.75,
-        4.0,
-        8.0,
-        32,
-        128,
-    ]
+    v = [-256, -64, -16, -4.75, -4.25, -1, -0.75, -0.125, 0.125, 0.75, 1, 1.5, 2.75, 4.0, 8.0, 32, 128]
     d = [-256, -64, -16, -1, -0.5, -0.125, 0.125, 0.5, 1, 2, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(d)):
@@ -367,30 +321,9 @@ def test_operations_with_combinations():
 
             assert (vx % vy) == (x % y)()
 
-
 def test_operations_with_constants_with_combinations():
-
-    v = [
-        -256,
-        -64,
-        -16,
-        -4.75,
-        -3.75,
-        -3.25,
-        -1,
-        -0.75,
-        -0.125,
-        0.0,
-        0.125,
-        0.75,
-        1,
-        1.5,
-        3.75,
-        4.0,
-        8.0,
-        32,
-        128,
-    ]
+    
+    v = [-256, -64, -16, -4.75, -3.75, -3.25, -1, -0.75, -0.125, 0.0, 0.125, 0.75, 1, 1.5, 3.75, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(v)):
             vx, vy = v[i], v[j]
@@ -411,25 +344,7 @@ def test_operations_with_constants_with_combinations():
             assert (x * vy)() == (vx * vy) == (vx * y)() == (x * y)()
             assert (vy * x)() == (vy * vx) == (y * vx)() == (y * x)()
 
-    v = [
-        -256,
-        -64,
-        -16,
-        -4.75,
-        -4.25,
-        -1,
-        -0.75,
-        -0.125,
-        0.125,
-        0.75,
-        1,
-        1.5,
-        2.75,
-        4.0,
-        8.0,
-        32,
-        128,
-    ]
+    v = [-256, -64, -16, -4.75, -4.25, -1, -0.75, -0.125, 0.125, 0.75, 1, 1.5, 2.75, 4.0, 8.0, 32, 128]
     d = [-256, -64, -16, -1, -0.5, -0.125, 0.125, 0.5, 1, 2, 4.0, 8.0, 32, 128]
     for i in range(len(v)):
         for j in range(len(d)):
@@ -446,11 +361,10 @@ def test_operations_with_constants_with_combinations():
             assert (x % vy)() == (vx % vy) == (vx % y)() == (x % y)()
             # assert (vy % x)() == (vy % vx) == (y % vx)() == (y % x)()
 
-
 def test_pow():
     x = Fxp(16, True, n_int=14, n_frac=8)
     n = Fxp(-1, True, n_int=14, n_frac=8)
-    assert (x**n)() == 1 / 16
+    assert(x**n)() == 1/16
 
     v = 15
     n_vals = [0, 1, 2, 3]
@@ -460,7 +374,7 @@ def test_pow():
     for n in n_vals:
         assert (x**n)() == v**n
         assert (xu**n)() == v**n
-
+    
     v = -16
     x = Fxp(v, signed=True, n_int=12, n_frac=0)
     for n in n_vals:
@@ -474,11 +388,11 @@ def test_pow():
     for n in n_vals:
         assert (x**n)() == v**n
         # assert (xu**n)() == v**n
-
+    
     v = -16.0
     x = Fxp(v, signed=True, n_int=14, n_frac=8)
     for n in n_vals:
-        assert (x**n)() == (v) ** n
+        assert (x**n)() == (v)**n
 
     v = 81
     n_vals = [0, 0.25, 0.5]
@@ -489,7 +403,8 @@ def test_pow():
         assert (x**n)() == v**n
         assert (xu**n)() == v**n
 
-    v = 16.0
+
+    v = 16.
     n = 2
     v_vals = [-4, -2, -1, 0, 1, 2, 4]
     n_vals = [-2, -1, 0, 1, 2]
@@ -503,14 +418,14 @@ def test_pow():
 
     x = Fxp(v, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x.config.op_sizing = "same"
+    x.config.op_sizing = 'same'
     assert ((x**p_vals)() == np.power(v, n_vals)).all()
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
     assert ((x**p_vals)() == np.power(v, n_vals)).all()
 
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p = Fxp(n, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = "same"
+    x_vals.config.op_sizing = 'same'
     assert ((x_vals**p)() == np.power(v_vals, n)).all()
     p = Fxp(n, signed=True, n_int=8, n_frac=2)
     assert ((x_vals**p)() == np.power(v_vals, n)).all()
@@ -519,33 +434,27 @@ def test_pow():
     n_vals = [-2, -1, 0, 1, 2]
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = "same"
-    assert (
-        (x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])
-    ).all()
+    x_vals.config.op_sizing = 'same'
+    assert ((x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])).all()
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=2)
-    assert (
-        (x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])
-    ).all()
+    assert ((x_vals**p_vals)() == np.array([vi**ni for vi, ni in zip(v_vals, n_vals)])).all()
 
-    v_vals = [[1, 2], [3, 4]]
-    n_vals = [[1, 2], [3, 4]]
+    v_vals = [[1, 2],[3, 4]]
+    n_vals = [[1, 2],[3, 4]]
     x_vals = Fxp(v_vals, signed=True, n_int=12, n_frac=8)
     p_vals = Fxp(n_vals, signed=True, n_int=8, n_frac=0)
-    x_vals.config.op_sizing = "same"
+    x_vals.config.op_sizing = 'same'
     assert ((x_vals**p_vals)() == np.power(v_vals, n_vals)).all()
-
 
 def test_scaled():
     x = Fxp(10.5, True, 16, 8, scale=2, bias=1)
 
     assert x() == 10.5
-
+    
     assert x + 2 == 12.5
     assert x - 2.5 == 8.0
     assert x * 3 == 31.5
     assert x / 2 == 5.25
-
 
 def test_abs():
     x = Fxp(-3.5, True, 32, 16)


### PR DESCRIPTION
## What This PR Achieves

After reviewing the fxpmath source, I saw that there was no current implementation for the 'Keep' shifting configuration, despite it being a valid option when constructing an `Fxp` object. This is important to me for the purpose of hardware modelling as i'd like a fixed-point type which:

- Retains a fixed size upon being shifted
- Discards bits which are shifted out of either end
- Correctly differentiates between arithmetic and logic shifts for signed numbers.

## Implementation Details

This PR implements that. The basic approach is to shift the raw value (as in the case of the 'expand' approach) however then bitmask the result with a mask of the form `01...1` where the number of 1's is equal to the input word size. We then create a new `Fxp` object from the masked value and return. 

Note,  when we construct the new value, we have to explicitly do so from a binary string with the formatting
```
f"0b{(shift & mask):0{n_word}b}"
```
This is necessary for two cases:

1. For a shift operation which leads to a value of `0b1` (i.e.`1 << 0`), this must be treated as `0b00..01` when calling `set_val()`, otherwise it will be treated as `Fxp('0b1', True, N, 0) = 0b11..11`
2. For a shift operation which puts a 1 into the MSB of a signed number, this should be treated with the correct signedness i.e. 
`0b0100 << 1 == 0b1000 == -8`. Without this formatting `0b0100 << 1` is treated as 8, which would not fit into a signed 4-bit value, and hence passing it to `set_val()` would cause the value to saturate and the resulting object would take on the value `0b0111 == 7`

## Tests

I have written some tests in `test_operators.py` to demonstrate the functionality. I anticipate that there may be a better way to achieve this behaviour without use of the string formatting,  so I am very open to suggestions before merging. 